### PR TITLE
Issue-12 / GHO-12: Integrate Tailscale on Flatcar Instance

### DIFF
--- a/docker/scripts/infra-shell.sh
+++ b/docker/scripts/infra-shell.sh
@@ -30,6 +30,16 @@ printf "🆔 Enter your Cloudflare Account ID: "
 IFS= read -r TF_VAR_cloudflare_account_id
 printf "\n"
 
+# Prompt for Tailscale API Key
+printf "🔐 Enter your Tailscale API Key: "
+IFS= read -rs TAILSCALE_API_KEY
+printf "\n"
+
+# Prompt for Tailscale TAILNET Name
+printf "🆔 Enter your Tailscale TAILNET Name: "
+IFS= read -r TAILSCALE_TAILNET
+printf "\n"
+
 # Discover caller public IPv4 and pass it to OpenTofu as admin_subnets
 MYIP="$(curl -fsS https://checkip.amazonaws.com | tr -d '\r\n')"
 if [[ -z "$MYIP" ]]; then
@@ -68,6 +78,8 @@ export R2_SECRET_ACCESS_KEY
 export TF_VAR_cloudflare_account_id
 export TF_VAR_cloudflare_api_token
 export CLOUDFLARE_API_TOKEN="$TF_VAR_cloudflare_api_token"
+export TAILSCALE_API_KEY
+export TAILSCALE_TAILNET
 
 # Ensure required secrets are available in the host environment
 : "${TF_VAR_vultr_api_key:?Environment variable not set}"
@@ -75,6 +87,8 @@ export CLOUDFLARE_API_TOKEN="$TF_VAR_cloudflare_api_token"
 : "${R2_SECRET_ACCESS_KEY:?Environment variable not set}"
 : "${TF_VAR_cloudflare_account_id:?Environment variable not set}"
 : "${TF_VAR_cloudflare_api_token:?Environment variable not set}"
+: "${TAILSCALE_API_KEY:?Environment variable not set}"
+: "${TAILSCALE_TAILNET:?Environment variable not set}"
 
 # Build container if needed
 docker build -t ghost_stack_shell ./docker
@@ -88,6 +102,8 @@ HISTFILE=/dev/null HISTSIZE=0 HISTFILESIZE=0 docker run --rm -it \
   -e TF_VAR_admin_subnets="$TF_VAR_admin_subnets" \
   -e R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" \
   -e R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" \
+  -e TAILSCALE_API_KEY="$TAILSCALE_API_KEY" \
+  -e TAILSCALE_TAILNET="$TAILSCALE_TAILNET" \
   -e USER_UID="$(id -u)" \
   -e USER_GID="$(id -g)" \
   -v "$(pwd)":/home/devops/app \

--- a/opentofu/envs/dev/.terraform.lock.hcl
+++ b/opentofu/envs/dev/.terraform.lock.hcl
@@ -31,6 +31,28 @@ provider "registry.opentofu.org/poseidon/ct" {
   ]
 }
 
+provider "registry.opentofu.org/tailscale/tailscale" {
+  version     = "0.22.0"
+  constraints = "~> 0.22.0"
+  hashes = [
+    "h1:ea+U0sogbfdVARt08Vm3KfNM5dVZ7XeXsrmegnCwde0=",
+    "zh:010bbf921898bc033ad47a338621e067083cb2aced3e88595444974f93e1ee37",
+    "zh:0b21d4f6af944b37965b777a21c85dab8c3070c934acaf077c1fd565e918fff6",
+    "zh:166b5448003a057fdb7693dd6ce4e02fd2b58fd3b46451b9e004632994c48640",
+    "zh:2b79dfa3fd96e4c835a7af82c3b939d9d667ed002589daa3e55ac5aac684c06b",
+    "zh:7c34b981ffab9911de38d85cc584a213f443bcedc46168001eacafcd23b720a7",
+    "zh:82724def61e6f885b4cd8199173f2670bf0925239b7c28ea0d775b4ba0e8dc78",
+    "zh:82850337b94aa69678be5532801784d2c0bed3dc42b63270c40b10a9f9b81bdc",
+    "zh:86a3479c2d87b44ad8e5bb9c95a3c6fc075575f2e3a09de05a8c610875d02517",
+    "zh:8b2f6733113136280f8787df6e1ad370a0658bf167bc9111317da78eef0b8d67",
+    "zh:8cc6b73014e78319915bf717768e725af85d65c81f1bf23e55f55a0a8ac9bf9a",
+    "zh:97fc3eecfd381c8136b1e003d7c3cbe29e6ca142d4de726c5080b9fa418ee6e6",
+    "zh:9f76e82dc4a37f300d32a1747195126465b2c86cceaba795a686b98e7d719b3d",
+    "zh:bdc5763d6394f2f3aa436fa0e12d82ffb28000fc24223c074abe2fd4434b8d97",
+    "zh:fc3f47f86a60a9fe9ec01ee61ffd0fc67f314075fdda45bb9d3b1f0c7953d86c",
+  ]
+}
+
 provider "registry.opentofu.org/vultr/vultr" {
   version     = "2.27.1"
   constraints = "~> 2.18, ~> 2.20, ~> 2.27"

--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -13,6 +13,10 @@ terraform {
         source  = "poseidon/ct"
         version = "0.13.0"
     }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.22.0"
+    }
   }
 }
 
@@ -34,6 +38,10 @@ data "terraform_remote_state" "bootstrap" {
   config = {
     path = "${path.module}/../../bootstrap/envs/dev/terraform.tfstate"
   }
+}
+
+module "tailscale" {
+  source              = "../../modules/tailscale"
 }
 
 module "dns_records" {
@@ -63,6 +71,7 @@ module "vm" {
   firewall_group_id = module.fw.id
   ghost_url         = var.ghost_url
   locksmith_mask    = var.locksmith_mask
+  tailscale_authkey = module.tailscale.tailscale_auth_key
 }
 
 module "block_storage" {

--- a/opentofu/envs/dev/tests/tailscale.tofutest.hcl
+++ b/opentofu/envs/dev/tests/tailscale.tofutest.hcl
@@ -1,0 +1,32 @@
+run "tailscale_auth_key_tests" {
+  command = plan
+
+  plan_options {
+    refresh = false
+  }
+
+  module {
+    source = "../../modules/tailscale"
+  }
+
+  assert {
+    condition     = tailscale_tailnet_key.this.preauthorized == true
+    error_message = "Tailscale key should be preauthorized"
+  }
+
+  assert {
+    condition     = tailscale_tailnet_key.this.reusable == true
+    error_message = "Tailscale key should be reusable"
+  }
+
+  assert {
+    condition     = tailscale_tailnet_key.this.ephemeral == false
+    error_message = "Tailscale key should not be ephemeral"
+  }
+
+  assert {
+    condition     = tailscale_tailnet_key.this.description == "Dev Ghost pre-approved auth key"
+    error_message = "Tailscale key should not be ephemeral"
+  }
+
+}

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.22.0"
+    }
+  }
+}
+
+resource "tailscale_tailnet_key" "this" {
+  reusable     = true
+  ephemeral    = false
+  preauthorized = true
+  description  = "Dev Ghost pre-approved auth key"
+}

--- a/opentofu/modules/tailscale/outputs.tofu
+++ b/opentofu/modules/tailscale/outputs.tofu
@@ -1,0 +1,5 @@
+output "tailscale_auth_key" {
+  value       = tailscale_tailnet_key.this.key
+  description = "Pre-authorized Tailscale auth key for dev Ghost instance"
+  sensitive   = true
+}

--- a/opentofu/modules/vultr/instance/main.tofu
+++ b/opentofu/modules/vultr/instance/main.tofu
@@ -30,8 +30,9 @@ resource "vultr_ssh_key" "this" {
 
 data "ct_config" "ghost" {
   content = templatefile("${path.module}/userdata/ghost.bu", {
-    ghost_service = local.ghost_service_b64,
-    locksmith_mask    = local.locksmith_mask
+    ghost_service     = local.ghost_service_b64,
+    locksmith_mask    = local.locksmith_mask,
+    tailscale_authkey = var.tailscale_authkey
   })
   strict       = true
 }

--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -31,6 +31,51 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
 
+    - path: /opt/tailscale-install.sh
+      mode: 0777
+      contents:
+        inline: |
+          #!/usr/bin/env bash
+          set -e
+        
+          # Only re-download if not already existing
+          if ! test -e /etc/tailscale; then
+            echo "Downloading tailscale"
+            wget https://pkgs.tailscale.com/stable/tailscale_1.88.1_amd64.tgz -O tailscale_1.88.1.tgz
+        
+            echo "Unpacking tailscale"
+            tar xvf tailscale_1.88.1.tgz -C /tmp
+        
+            echo "Removing tgz"
+            rm tailscale_1.88.1.tgz
+        
+            echo "Moving binaries (if not exist)"
+            sudo mkdir -p /etc/tailscale
+            sudo cp -n /tmp/tailscale_1.88.1_amd64/tailscale /etc/tailscale/tailscale
+            sudo cp -n /tmp/tailscale_1.88.1_amd64/tailscaled /etc/tailscale/tailscaled
+        
+            echo "Enabling service"
+            sudo systemctl enable tailscaled.service
+        
+            echo "Reloading systemd"
+            systemctl daemon-reload
+        
+            echo "Cleaning up tmp folder"
+            rm -r /tmp/tailscale_1.88.1_amd64
+          fi
+        
+          echo "Starting service"
+          sudo systemctl restart tailscaled.service
+        
+          echo "Allowing IP forwarding"
+          sudo rm -f /etc/sysctl.d/99-tailscale.conf
+          echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
+          echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
+          sudo sysctl -p /etc/sysctl.d/99-tailscale.conf
+          
+          echo "Bringing up Tailscale interface"
+          sudo /etc/tailscale/tailscale up --authkey=${tailscale_authkey}
+
   links:
     - target: /opt/extensions/docker-compose/docker-compose-2.34.0-x86-64.raw
       path: /etc/extensions/docker-compose.raw
@@ -67,6 +112,55 @@ systemd:
         mkdir -p /var/mnt/storage/mysql/data && chmod 0755 /var/mnt/storage/mysql/data\'
         RemainAfterExit=true
         
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: tailscale-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Run Tailscale installation script
+        Wants=network-online.target
+        After=network.target network-online.target
+        ConditionPathExists=/opt/tailscale-install.sh
+        ConditionPathExists=!/etc/tailscale/tailscaled
+
+        [Service]
+        Type=forking
+        TimeoutStartSec=180
+        RemainAfterExit=yes
+        KillMode=process
+        ExecStartPre=/bin/sleep 30
+        ExecStart=/usr/bin/sh -c "/opt/tailscale-install.sh"
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: tailscaled.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Tailscale node agent
+        Documentation=https://tailscale.com/kb/
+        Wants=network-pre.target tailscale-install.service
+        After=network-pre.target NetworkManager.service systemd-resolved.service
+
+        [Service]
+        User=0
+        Group=0
+        ExecStartPre=/etc/tailscale/tailscaled --cleanup
+        ExecStart=/etc/tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=41641
+        ExecStopPost=/etc/tailscale/tailscaled --cleanup
+        Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin:/etc/tailscale"
+        Restart=on-failure
+        RuntimeDirectory=tailscale
+        RuntimeDirectoryMode=0755
+        StateDirectory=tailscale
+        StateDirectoryMode=0700
+        CacheDirectory=tailscale
+        CacheDirectoryMode=0750
+        Type=notify
+
         [Install]
         WantedBy=multi-user.target
 

--- a/opentofu/modules/vultr/instance/variables.tofu
+++ b/opentofu/modules/vultr/instance/variables.tofu
@@ -46,3 +46,8 @@ variable "locksmith_mask" {
   type        = bool
   default     = true
 }
+
+variable "tailscale_authkey" {
+  type      = string
+  sensitive = true
+}

--- a/opentofu/scripts/tofu.sh
+++ b/opentofu/scripts/tofu.sh
@@ -124,7 +124,7 @@ case "${ACTION}" in
     tofu -chdir="${ENV_DIR}" init -reconfigure -backend-config="${OUT}" "${EXTRA_ARGS[@]}"
     ;;
 
-  plan|apply|destroy|taint|state|output)
+  plan|apply|destroy|taint|state|test|show|output)
     # Always ensure backend is generated and initialized (cheap & robust)
     ensure_backend
     # For provider auth (e.g., Vultr), expect env to be exported outside this script.
@@ -132,7 +132,7 @@ case "${ACTION}" in
     ;;
 
   *)
-    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|output> [extra args...]"
+    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|test|show|output> [extra args...]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Issue-12 / GHO-12
- Added test option to tofu wrapper script to support using Terraform/Tofu test
- Added show option to tofu wrapper script to support debugging story
- Added tailscale Tofu module to provision pre-authorized key for vulr instance running Ghost environment
- Update vultr flatcar instance butane config to download and install tailscale, create a systemd service for it
- Inject the tailscale pre-auth key into butane configs
- Update infra-shell script to inject tailscale api key and tailnet name
- Added tofu test to validate tailscale auth key creation