### PR TITLE
Issue-13 / GHO-13: Restrict SSH Access to Tailscale

### DIFF
--- a/opentofu/envs/dev/tests/tailscale.tofutest.hcl
+++ b/opentofu/envs/dev/tests/tailscale.tofutest.hcl
@@ -30,3 +30,59 @@ run "tailscale_auth_key_tests" {
   }
 
 }
+
+run "acl-policy-is-correct" {
+  command = plan
+
+  plan_options {
+    refresh = false
+  }
+
+  module {
+    source = "../../modules/tailscale"
+  }
+
+  assert {
+    condition     = tailscale_acl.my_tailnet_acl.acl != null
+    error_message = "ACL should not be null"
+  }
+
+  assert {
+    condition = (
+      length(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants) == 1 &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].dst, "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].ip, "22")
+    )
+    error_message = "ACL grants should contain correct source, destination, and port 22"
+  }
+
+  assert {
+    condition = (
+      length(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh) == 1 &&
+      jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].action == "accept" &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].dst, "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "root") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "autogroup:nonroot") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "core")
+    )
+    error_message = "SSH rules should allow access from noah@noahwhite.net to tag:ghost-dev with correct users"
+  }
+
+  assert {
+    condition = (
+      contains(keys(jsondecode(tailscale_acl.my_tailnet_acl.acl).groups), "group:devs") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).groups["group:devs"], "noah@noahwhite.net")
+    )
+    error_message = "Groups should contain group:devs with noah@noahwhite.net as member"
+  }
+
+  assert {
+    condition = (
+      contains(keys(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners), "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners["tag:ghost-dev"], "group:devs")
+    )
+    error_message = "Tag owners should assign tag:ghost-dev to group:devs"
+  }
+}

--- a/opentofu/envs/dev/tests/vultr-firewall.tofutest.hcl
+++ b/opentofu/envs/dev/tests/vultr-firewall.tofutest.hcl
@@ -1,0 +1,190 @@
+mock_provider "vultr" {
+  mock_data "vultr_firewall_group" {
+    defaults = {
+      id          = "test-firewall-group-id"
+      description = "test-firewall"
+    }
+  }
+}
+
+run "firewall_group_tests" {
+  command = plan
+
+  module {
+    source = "../../modules/vultr/firewall"
+  }
+
+  variables {
+    name = "test-firewall"
+    admin_subnets = [
+      {
+        subnet      = "192.168.1.0"
+        subnet_size = 24
+      },
+      {
+        subnet      = "10.0.0.1"
+        subnet_size = 32
+      }
+    ]
+  }
+
+  assert {
+    condition     = vultr_firewall_group.this.description == "test-firewall"
+    error_message = "Firewall group description should match the provided name"
+  }
+
+  assert {
+    condition     = vultr_firewall_group.this.id != null
+    error_message = "Firewall group should have an ID"
+  }
+}
+
+run "http_https_rules_tests" {
+  command = plan
+
+  module {
+    source = "../../modules/vultr/firewall"
+  }
+
+  variables {
+    name = "test-firewall"
+    admin_subnets = [
+      {
+        subnet      = "192.168.1.0"
+        subnet_size = 24
+      },
+      {
+        subnet      = "10.0.0.1"
+        subnet_size = 32
+      }
+    ]
+  }
+
+  # Test HTTP rules
+  assert {
+    condition = (
+      length(vultr_firewall_rule.http) == 2 &&
+      vultr_firewall_rule.http["0"].protocol == "tcp" &&
+      vultr_firewall_rule.http["0"].ip_type == "v4" &&
+      vultr_firewall_rule.http["0"].port == "80" &&
+      vultr_firewall_rule.http["0"].subnet == "192.168.1.0" &&
+      vultr_firewall_rule.http["0"].subnet_size == 24 &&
+      vultr_firewall_rule.http["0"].notes == "HTTP"
+    )
+    error_message = "HTTP rules should be correctly configured for admin subnets"
+  }
+
+  # Test HTTPS rules
+  assert {
+    condition = (
+      length(vultr_firewall_rule.https) == 2 &&
+      vultr_firewall_rule.https["0"].protocol == "tcp" &&
+      vultr_firewall_rule.https["0"].ip_type == "v4" &&
+      vultr_firewall_rule.https["0"].port == "443" &&
+      vultr_firewall_rule.https["0"].subnet == "192.168.1.0" &&
+      vultr_firewall_rule.https["0"].subnet_size == 24 &&
+      vultr_firewall_rule.https["0"].notes == "HTTPS"
+    )
+    error_message = "HTTPS rules should be correctly configured for admin subnets"
+  }
+
+  # Test second subnet rules
+  assert {
+    condition = (
+      vultr_firewall_rule.http["1"].subnet == "10.0.0.1" &&
+      vultr_firewall_rule.http["1"].subnet_size == 32 &&
+      vultr_firewall_rule.https["1"].subnet == "10.0.0.1" &&
+      vultr_firewall_rule.https["1"].subnet_size == 32
+    )
+    error_message = "Rules should be created for all admin subnets"
+  }
+}
+
+run "cloudflare_rules_tests" {
+  command = plan
+
+  module {
+    source = "../../modules/vultr/firewall"
+  }
+
+  variables {
+    name = "test-firewall"
+    admin_subnets = []
+  }
+
+  # Test that Cloudflare rules are created
+  assert {
+    condition     = length(vultr_firewall_rule.allow_https_from_cloudflare) == 15
+    error_message = "Should create 15 Cloudflare HTTPS rules for all IP ranges"
+  }
+
+  # Test a specific Cloudflare rule configuration
+  assert {
+    condition = (
+      vultr_firewall_rule.allow_https_from_cloudflare["173.245.48.0/20"].protocol == "tcp" &&
+      vultr_firewall_rule.allow_https_from_cloudflare["173.245.48.0/20"].ip_type == "v4" &&
+      vultr_firewall_rule.allow_https_from_cloudflare["173.245.48.0/20"].port == "443" &&
+      vultr_firewall_rule.allow_https_from_cloudflare["173.245.48.0/20"].subnet == "173.245.48.0" &&
+      vultr_firewall_rule.allow_https_from_cloudflare["173.245.48.0/20"].subnet_size == 20
+    )
+    error_message = "Cloudflare rules should be correctly configured with proper subnet and size"
+  }
+
+  # Test another Cloudflare rule to ensure proper CIDR parsing
+  assert {
+    condition = (
+      vultr_firewall_rule.allow_https_from_cloudflare["104.16.0.0/13"].subnet == "104.16.0.0" &&
+      vultr_firewall_rule.allow_https_from_cloudflare["104.16.0.0/13"].subnet_size == 13 &&
+      strcontains(vultr_firewall_rule.allow_https_from_cloudflare["104.16.0.0/13"].notes, "Cloudflare")
+    )
+    error_message = "Cloudflare rules should parse CIDR blocks correctly and include descriptive notes"
+  }
+}
+
+run "outputs_test" {
+  command = plan
+
+  module {
+    source = "../../modules/vultr/firewall"
+  }
+
+  variables {
+    name = "test-firewall"
+    admin_subnets = []
+  }
+
+  assert {
+    condition     = output.id == vultr_firewall_group.this.id
+    error_message = "Output ID should match the firewall group ID"
+  }
+}
+
+run "no_admin_subnets_test" {
+  command = plan
+
+  module {
+    source = "../../modules/vultr/firewall"
+  }
+
+  variables {
+    name = "test-firewall"
+    admin_subnets = []
+  }
+
+  # When no admin subnets are provided, HTTP/HTTPS rules should not be created
+  assert {
+    condition     = length(vultr_firewall_rule.http) == 0
+    error_message = "No HTTP rules should be created when admin_subnets is empty"
+  }
+
+  assert {
+    condition     = length(vultr_firewall_rule.https) == 0
+    error_message = "No HTTPS rules should be created when admin_subnets is empty"
+  }
+
+  # But Cloudflare rules should still exist
+  assert {
+    condition     = length(vultr_firewall_rule.allow_https_from_cloudflare) == 15
+    error_message = "Cloudflare rules should always be created regardless of admin_subnets"
+  }
+}

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -8,8 +8,36 @@ terraform {
 }
 
 resource "tailscale_tailnet_key" "this" {
-  reusable     = true
-  ephemeral    = false
+  reusable      = true
+  ephemeral     = false
   preauthorized = true
-  description  = "Dev Ghost pre-approved auth key"
+  description   = "Dev Ghost pre-approved auth key"
+  tags          = ["tag:ghost-dev"]
+}
+
+resource "tailscale_acl" "my_tailnet_acl" {
+  acl = jsonencode({
+    "grants" = [
+      {
+        "src": ["noah@noahwhite.net"],
+        "dst": ["tag:ghost-dev"],
+        "ip":  ["22"]
+      }
+    ],
+    "ssh" = [
+      # SSH access rules
+      {
+        "action" = "accept",
+        "src"    = ["noah@noahwhite.net"],
+        "dst"    = ["tag:ghost-dev"],
+        "users"  = ["root", "autogroup:nonroot", "core"],
+      }
+    ],
+    "groups" = {
+      "group:devs" = ["noah@noahwhite.net"]
+    },
+    "tagOwners" = {
+      "tag:ghost-dev"     = ["group:devs"]
+    },
+  })
 }

--- a/opentofu/modules/vultr/firewall/main.tofu
+++ b/opentofu/modules/vultr/firewall/main.tofu
@@ -37,18 +37,6 @@ resource "vultr_firewall_group" "this" {
 # IPv4 rules
 # ----------------
 
-# SSH from admin subnets
-resource "vultr_firewall_rule" "ssh_admin" {
-  for_each          = { for i, s in var.admin_subnets : i => s }
-  firewall_group_id = vultr_firewall_group.this.id
-  protocol          = "tcp"
-  ip_type           = "v4"
-  subnet            = each.value.subnet
-  subnet_size       = each.value.subnet_size
-  port              = "22"
-  notes             = "SSH (admin subnet)"
-}
-
 # HTTP/HTTPS from anywhere
 resource "vultr_firewall_rule" "http" {
   for_each          = { for i, s in var.admin_subnets : i => s }

--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -39,20 +39,20 @@ storage:
           set -e
         
           # Only re-download if not already existing
-          if ! test -e /etc/tailscale; then
+          if ! test -e /opt/tailscale; then
             echo "Downloading tailscale"
-            wget https://pkgs.tailscale.com/stable/tailscale_1.88.1_amd64.tgz -O tailscale_1.88.1.tgz
+            wget https://pkgs.tailscale.com/stable/tailscale_1.88.3_amd64.tgz -O tailscale_1.88.3.tgz
         
             echo "Unpacking tailscale"
-            tar xvf tailscale_1.88.1.tgz -C /tmp
+            tar xvf tailscale_1.88.3.tgz -C /tmp
         
             echo "Removing tgz"
-            rm tailscale_1.88.1.tgz
+            rm tailscale_1.88.3.tgz
         
             echo "Moving binaries (if not exist)"
-            sudo mkdir -p /etc/tailscale
-            sudo cp -n /tmp/tailscale_1.88.1_amd64/tailscale /etc/tailscale/tailscale
-            sudo cp -n /tmp/tailscale_1.88.1_amd64/tailscaled /etc/tailscale/tailscaled
+            sudo mkdir -p /opt/tailscale
+            sudo cp -n /tmp/tailscale_1.88.3_amd64/tailscale /opt/tailscale/tailscale
+            sudo cp -n /tmp/tailscale_1.88.3_amd64/tailscaled /opt/tailscale/tailscaled
         
             echo "Enabling service"
             sudo systemctl enable tailscaled.service
@@ -61,20 +61,14 @@ storage:
             systemctl daemon-reload
         
             echo "Cleaning up tmp folder"
-            rm -r /tmp/tailscale_1.88.1_amd64
+            rm -r /tmp/tailscale_1.88.3_amd64
           fi
         
           echo "Starting service"
           sudo systemctl restart tailscaled.service
-        
-          echo "Allowing IP forwarding"
-          sudo rm -f /etc/sysctl.d/99-tailscale.conf
-          echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
-          echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
-          sudo sysctl -p /etc/sysctl.d/99-tailscale.conf
           
           echo "Bringing up Tailscale interface"
-          sudo /etc/tailscale/tailscale up --authkey=${tailscale_authkey}
+          sudo /opt/tailscale/tailscale up --authkey=${tailscale_authkey} --ssh
 
   links:
     - target: /opt/extensions/docker-compose/docker-compose-2.34.0-x86-64.raw
@@ -123,7 +117,7 @@ systemd:
         Wants=network-online.target
         After=network.target network-online.target
         ConditionPathExists=/opt/tailscale-install.sh
-        ConditionPathExists=!/etc/tailscale/tailscaled
+        ConditionPathExists=!/opt/tailscale/tailscaled
 
         [Service]
         Type=forking
@@ -146,13 +140,12 @@ systemd:
         After=network-pre.target NetworkManager.service systemd-resolved.service
 
         [Service]
-        User=0
-        Group=0
-        ExecStartPre=/etc/tailscale/tailscaled --cleanup
-        ExecStart=/etc/tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=41641
-        ExecStopPost=/etc/tailscale/tailscaled --cleanup
-        Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin:/etc/tailscale"
+        Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin:/opt/tailscale"
+        ExecStart=/opt/tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=41641
+        ExecStopPost=/opt/tailscale/tailscaled --cleanup
+  
         Restart=on-failure
+  
         RuntimeDirectory=tailscale
         RuntimeDirectoryMode=0755
         StateDirectory=tailscale

--- a/opentofu/scripts/tofu.sh
+++ b/opentofu/scripts/tofu.sh
@@ -124,7 +124,7 @@ case "${ACTION}" in
     tofu -chdir="${ENV_DIR}" init -reconfigure -backend-config="${OUT}" "${EXTRA_ARGS[@]}"
     ;;
 
-  plan|apply|destroy|taint|state|test|show|output)
+  plan|apply|destroy|taint|state|import|test|show|output)
     # Always ensure backend is generated and initialized (cheap & robust)
     ensure_backend
     # For provider auth (e.g., Vultr), expect env to be exported outside this script.
@@ -132,7 +132,7 @@ case "${ACTION}" in
     ;;
 
   *)
-    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|test|show|output> [extra args...]"
+    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|import|test|show|output> [extra args...]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
- Update butane config to use the latest stable tailscale distribution and place files in /opt, also removed unnecessary IP forwarding configuration and start the ssh server, removed unnecessary ExecStartPre to bring systemd unit inline with the one which ships with tailscale
- Added tailscale ACL to only permit ssh  from my account to the ghost-dev instance
- Added tofu tests for tailscale acl resource and vultr firewall resource
- Updated vultr firewall resource to remove the ssh/port 22 allow rule. Now all ssh must go through tailscale path
- Added import support to tofu wrapper to allow import of baseline tailscale ACL state
- GHO-13 / ISSUE-13