### PR TITLE
GHO-23: Generate and publish OpenTofu plan output as CI artifact

### DIFF
--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -163,3 +163,18 @@ jobs:
             -e TF_VAR_cloudflare_zone_id \
             ghcr.io/noahwhite/ghost-stack-shell:latest \
             bash -c "git config --global --add safe.directory /home/devops/app && ./opentofu/scripts/tofu.sh dev plan -out=tfplan"
+
+      - name: Generate human-readable plan output
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/home/devops/app" \
+            -w /home/devops/app \
+            ghcr.io/noahwhite/ghost-stack-shell:latest \
+            bash -c "git config --global --add safe.directory /home/devops/app && tofu -chdir=opentofu/envs/dev show -no-color tfplan > opentofu/envs/dev/plan-output.txt"
+
+      - name: Upload plan as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tofu-plan-dev-${{ github.event.pull_request.number }}
+          path: opentofu/envs/dev/plan-output.txt
+          retention-days: 30


### PR DESCRIPTION
## Summary

  Generate and publish OpenTofu plan output as a CI artifact so that reviewers can inspect proposed infrastructure changes before merge.

  ## Changes

  - Added step to generate human-readable plan output using `tofu show -no-color tfplan`
  - Added step to upload plan output as GitHub Actions artifact
  - Artifact named `tofu-plan-dev-<PR#>` with 30-day retention
  - Plan output accessible from GitHub Actions run page

  ## Test plan

  - [x] Plan output saved to file
  - [x] File uploaded as CI artifact
  - [x] Verify artifact is accessible from Actions run
  - [x] No infrastructure changes applied