### PR TITLE
feature/GHO-26-Trigger

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -251,6 +251,8 @@ jobs:
 
       - name: Verify Ghost health after deployment
         if: env.PLANS_MATCH == 'true'
+        env:
+          HEALTH_CHECK_TOKEN: ${{ secrets.HEALTH_CHECK_TOKEN }}
         run: |
           echo "🏥 Starting health checks for Ghost deployment..."
 
@@ -260,7 +262,9 @@ jobs:
 
           for i in $(seq 1 $MAX_RETRIES); do
             echo "Health check attempt $i of $MAX_RETRIES..."
-            HTTP_CODE=$(curl -fsSL --max-time 10 -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
+            HTTP_CODE=$(curl -sSL --max-time 10 -o /dev/null -w "%{http_code}" \
+              -H "X-Health-Check-Token: ${HEALTH_CHECK_TOKEN}" \
+              "$URL" 2>&1 || echo "000")
 
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✅ Ghost is healthy - received HTTP $HTTP_CODE"


### PR DESCRIPTION
## Summary
  - Add shared secret token authentication for health checks
  - Health check requests now include `X-Health-Check-Token` header for Caddy verification
  - Token stored in GitHub Secrets (`HEALTH_CHECK_TOKEN` in `dev` environment)

  ## Changes
  - Updated `deploy-dev.yml` to pass authentication token in curl header
  - Token is injected via environment variable from GitHub Secrets