### PR TITLE
GHO-31: Add Linear MCP server configuration for Claude Code

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {
+        "Authorization": "Bearer ${LINEAR_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
  Add Linear MCP server configuration to enable Claude Code integration with Linear for project management.

  ## Changes
  - Add `.mcp.json` with Linear MCP server configuration
  - Uses HTTP transport type pointing to `https://mcp.linear.app/mcp`
  - API key referenced via `${LINEAR_API_KEY}` environment variable for security

  ## Setup Required
  Team members need to set the `LINEAR_API_KEY` environment variable before starting Claude Code:

  ```zsh
read -s LINEAR_API_KEY
export LINEAR_API_KEY
  ```
  Or add to docker-compose environment section if running Claude Code in a container.

  Capabilities Enabled

  With this configuration, Claude Code can:
  - List teams, projects, cycles, and issues
  - Create and update issues
  - Add comments to issues
  - Read project details and status

  Acceptance Criteria

  - .mcp.json file exists in repository root
  - Linear MCP server configured with HTTP transport type
  - API key referenced via environment variable
  - Configuration works when LINEAR_API_KEY is set (verify after merge)
  - Claude Code can list teams, projects, and issues

  Linear Story

  https://linear.app/noahwhite/issue/GHO-31/user-story-add-linear-mcp-server-configuration-for-claude-code
