### PR TITLE
feature/add-claude-md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,13 @@ You are a staff-level infrastructure and application engineer/architect. Provide
 - Follow existing test patterns (see `grafana-cloud.tofutest.hcl`, `vultr-firewall.tofutest.hcl`, `tailscale.tofutest.hcl`)
 - When staging and prod environments are added, tests will follow the same pattern under `opentofu/envs/<env>/tests/`
 
+## Linear Integration
+
+- **Always set Noah White as the project lead** when creating new projects
+- Use the `ghost-stack` team for all issues and projects
+- Include detailed acceptance criteria in issue descriptions
+- Link related issues using dependencies where applicable
+
 ## Project Overview
 
 Ghost Stack is an infrastructure-as-code project for deploying a self-hosted Ghost blog on Flatcar Container Linux. The stack runs on Vultr cloud with Cloudflare for DNS/CDN, Caddy as reverse proxy, and uses OpenTofu for infrastructure provisioning.


### PR DESCRIPTION
  ## Summary
  Updates CLAUDE.md to document Linear integration requirements for project management.

  ## Changes
  - Added new **Linear Integration** section after Testing Requirements
  - Documents requirement to always set Noah White as project lead when creating Linear projects
  - Specifies the `ghost-stack` team should be used for all issues and projects
  - Includes guidelines for issue descriptions and dependencies

  ## Context
  This requirement was identified while creating the Alloy Sysext Build Repository & Automation project (GHO-32 through
  GHO-38). The project was initially created without a lead assigned, and this documentation ensures future projects are
   properly configured from the start.

  ## Location
  The new section is placed between "Testing Requirements" and "Project Overview" sections for logical flow, as project
  management configuration is relevant before diving into project-specific details.