### PR TITLE
Fix false positive drift detection from ephemeral Vultr KVM URL

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -194,7 +194,17 @@ jobs:
       - name: Compare PR plan with current plan
         run: |
           echo "Comparing PR plan with current state..."
-          if diff -u ./pr-plan/plan-output.txt ./opentofu/envs/dev/current-plan.txt; then
+
+          # Filter out ephemeral values that change between plan runs
+          # - kvm: Vultr KVM console URL contains session tokens that regenerate on every API call
+          filter_ephemeral() {
+            grep -v '~ kvm'
+          }
+
+          filter_ephemeral < ./pr-plan/plan-output.txt > /tmp/pr-plan-filtered.txt
+          filter_ephemeral < ./opentofu/envs/dev/current-plan.txt > /tmp/current-plan-filtered.txt
+
+          if diff -u /tmp/pr-plan-filtered.txt /tmp/current-plan-filtered.txt; then
             echo "✅ Plans match - no drift detected"
             echo "PLANS_MATCH=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Summary

Fix false positive drift detection in the deploy workflow caused by ephemeral values in the OpenTofu plan output.

## Problem

The Vultr provider returns a `kvm` attribute containing a KVM console URL with session tokens that regenerate on every API call. This causes the plan comparison to always fail with:

```
❌ Plans differ - state has drifted since PR approval
```

Even when there's no actual infrastructure drift.

## Solution

Filter out known ephemeral values before comparing the PR plan with the current plan:

```bash
filter_ephemeral() {
  grep -v '~ kvm'
}
```

This removes lines containing `~ kvm` (the changed KVM URL) from both plans before diffing.

## Test plan

- [x] Merge this PR
- [x] Re-run the failed deploy workflow for PR #73
- [x] Verify the plan comparison passes and deployment proceeds