### PR TITLE
Fix vultr-cli attach flag syntax

### DIFF
--- a/opentofu/modules/vultr/block_storage/main.tofu
+++ b/opentofu/modules/vultr/block_storage/main.tofu
@@ -72,7 +72,7 @@ resource "null_resource" "attach_block_storage" {
 
       # Attach to the new instance
       echo "Attaching block storage to instance $INSTANCE_ID..."
-      vultr-cli block-storage attach "$BLOCK_STORAGE_ID" --instance-id="$INSTANCE_ID" --live || true
+      vultr-cli block-storage attach "$BLOCK_STORAGE_ID" --instance="$INSTANCE_ID" --live || true
 
       # Verify attachment
       echo "Verifying block storage attachment..."


### PR DESCRIPTION
## Summary

Fixes the vultr-cli block-storage attach command flag.

**Error:** `Error: unknown flag: --instance-id`

**Fix:** Change `--instance-id` to `--instance` per [Vultr CLI documentation](https://docs.vultr.com/reference/vultr-cli/block-storage).

## Test plan

- [x] PR plan workflow passes
- [x] Deploy succeeds with block storage attachment