### PR TITLE
Fix vultr-cli output parsing for block storage verification

### DIFF
--- a/opentofu/modules/vultr/block_storage/main.tofu
+++ b/opentofu/modules/vultr/block_storage/main.tofu
@@ -58,7 +58,7 @@ resource "null_resource" "attach_block_storage" {
       sleep 30
 
       echo "Checking current block storage state..."
-      CURRENT_ATTACHED=$(vultr-cli block-storage get "$BLOCK_STORAGE_ID" | grep "ATTACHED TO INSTANCE" | awk '{print $4}')
+      CURRENT_ATTACHED=$(vultr-cli block-storage get "$BLOCK_STORAGE_ID" | tail -n1 | awk '{print $3}')
       echo "Currently attached to: $${CURRENT_ATTACHED:-none}"
 
       # If attached to something (possibly stale/deleted instance), detach first
@@ -77,7 +77,7 @@ resource "null_resource" "attach_block_storage" {
       # Verify attachment
       echo "Verifying block storage attachment..."
       sleep 5
-      VERIFIED_ATTACHED=$(vultr-cli block-storage get "$BLOCK_STORAGE_ID" | grep "ATTACHED TO INSTANCE" | awk '{print $4}')
+      VERIFIED_ATTACHED=$(vultr-cli block-storage get "$BLOCK_STORAGE_ID" | tail -n1 | awk '{print $3}')
 
       if [ "$VERIFIED_ATTACHED" = "$INSTANCE_ID" ]; then
         echo "Verification successful: block storage is attached to $INSTANCE_ID"


### PR DESCRIPTION
## Summary

Fixes the parsing of `vultr-cli block-storage get` output to correctly extract the INSTANCE ID.

**Problem:** The script was using `grep "ATTACHED TO INSTANCE"` but the CLI outputs a table format:

```
ID                    REGION ID    INSTANCE ID                SIZE GB    ...
8e499d90-...          ewr          afb11f23-...               25         ...
```

**Fix:** Use `tail -n1 | awk '{print $3}'` to extract column 3 (INSTANCE ID) from the data row.

## Test plan

- [x] Verified locally: `vultr-cli block-storage get ... | tail -n1 | awk '{print $3}'` returns the correct instance ID
- [x] PR plan workflow passes
- [x] Deploy succeeds with block storage attachment and verification