### PR TITLE
chore: retrigger deployment for ephemeral compose

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-# GHO-26: Testing health checks after deployment
+# GHO-26: Health checks after deployment
 name: Deploy to Dev Environment
 
 on:


### PR DESCRIPTION
## Summary

Retrigger deployment workflow to generate fresh plan artifact after previous deployment failed due to:
1. Alloy sysext download timeout (network issue)
2. Plan drift from Tailscale auth key regeneration

This PR contains only a trivial comment change to trigger the workflow.

## Test Plan

- [ ] PR workflow generates fresh plan
- [ ] Merge and deploy succeeds
- [ ] Ghost site accessible after deployment