### PR TITLE
fix: add overwrite flag to locksmith.conf in Ignition

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -90,6 +90,7 @@ storage:
 
     - path: /etc/locksmith/locksmith.conf
       mode: 0644
+      overwrite: true
       contents:
         source: "data:text/plain;charset=utf-8;base64,UkVCT09UX1NUUkFURUdZPXJlYm9vdApMT0NLU01JVEhEX1JFQk9PVF9XSU5ET1dfU1RBUlQ9MDI6MDAKTE9DS1NNSVRIRF9SRUJPT1RfV0lORE9XX0xFTkdUSD0yaAo="
 


### PR DESCRIPTION
## Summary

Flatcar's newer stable image includes a default `/etc/locksmith/locksmith.conf` file. Ignition fails to create our custom config unless `overwrite: true` is set.

This fixes the Ignition boot failure:
```
CRITICAL: Ignition failed: failed to create files: error creating /sysroot/etc/locksmith/locksmith.conf: a file exists there already and overwrite is false
```

## Test Plan

- [ ] Instance boots successfully with Ignition
- [ ] Ghost site accessible after deployment
- [ ] Health checks pass