### PR TITLE
fix: add tailscale-auth.service dependency to tailscale-monitor

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -214,7 +214,7 @@ systemd:
       contents: |
         [Unit]
         Description=Tailscale Connection Monitor
-        After=network-online.target var-mnt-storage.mount tailscaled.service
+        After=network-online.target var-mnt-storage.mount tailscaled.service tailscale-auth.service
         Wants=network-online.target
         Requires=var-mnt-storage.mount
 


### PR DESCRIPTION
## Summary

On first boot, the tailscale-monitor timer can fire before `tailscale-auth.service` completes authentication. This causes the monitor script to fail because Tailscale isn't connected yet.

Adding `After=tailscale-auth.service` ensures the monitor waits for authentication to complete on first boot. On subsequent boots, `tailscale-auth.service` doesn't run (due to `ConditionPathExists` check) so the dependency is safely ignored.

## Test Plan

- [ ] On fresh instance boot, tailscale-monitor.service should not fail
- [ ] Timer-triggered runs should continue to work normally