### PR TITLE
fix(ci): filter allowed_bandwidth from drift detection

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -199,8 +199,9 @@ jobs:
 
           # Filter out ephemeral values that change between plan runs
           # - kvm: Vultr KVM console URL contains session tokens that regenerate on every API call
+          # - allowed_bandwidth: Vultr bandwidth allocation changes over time (monthly reset/accumulation)
           filter_ephemeral() {
-            grep -v '~ kvm'
+            grep -v '~ kvm' | grep -v '~ allowed_bandwidth'
           }
 
           filter_ephemeral < ./pr-plan/plan-output.txt > /tmp/pr-plan-filtered.txt


### PR DESCRIPTION
## Summary

Filter `allowed_bandwidth` from drift detection in the deploy workflow.

## Problem

Vultr's `allowed_bandwidth` attribute changes over time due to monthly bandwidth allocation resets/accumulation. This causes false drift detection failures:

```
-      ~ allowed_bandwidth = 85 -> (known after apply)
+      ~ allowed_bandwidth = 91 -> (known after apply)
```

## Solution

Add `allowed_bandwidth` to the ephemeral value filter alongside `kvm`:

```bash
filter_ephemeral() {
  grep -v '~ kvm' | grep -v '~ allowed_bandwidth'
}
```

## Test plan

- [ ] Merge this PR
- [ ] Verify subsequent deployments pass drift detection