### PR TITLE
fix(tailscale): remove invalid characters from auth key description

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -11,7 +11,7 @@ resource "tailscale_tailnet_key" "this" {
   reusable      = false # One-time key - invalidated after first use for security
   ephemeral     = false
   preauthorized = true
-  description   = "Dev Ghost pre-approved auth key (one-time)"
+  description   = "Dev Ghost pre-approved one-time auth key"
   tags          = ["tag:ghost-dev"]
 }
 


### PR DESCRIPTION
## Summary

Fix Tailscale API error caused by parentheses in auth key description.

## Problem

```
Error: Failed to create key
keys: description had invalid characters (400)
```

The description `"Dev Ghost pre-approved auth key (one-time)"` contains parentheses which Tailscale API rejects.

## Solution

Change to `"Dev Ghost pre-approved one-time auth key"` (no parentheses).

## Test plan

- [ ] Merge and verify deployment succeeds
- [ ] Verify Tailscale key is created with correct description