### PR TITLE
fix(ci): escape commit message in PR number extraction

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Extract PR number from merge commit
         id: pr
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          PR_NUM=$(echo "${{ github.event.head_commit.message }}" | grep -oP '\(#\K\d+(?=\))')
+          PR_NUM=$(echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' | head -1)
           if [ -z "$PR_NUM" ]; then
             echo "❌ No PR number found in commit message"
             echo "   This deployment requires a PR merge commit"


### PR DESCRIPTION
## Summary

Fix shell syntax error when commit messages contain special characters like parentheses.

## Problem

```
/home/runner/work/_temp/xxx.sh: line 4: syntax error near unexpected token `('
```

The commit message `fix(tailscale): remove invalid characters from auth key description (#102)` contains parentheses that break shell parsing when directly interpolated via `${{ github.event.head_commit.message }}`.

## Solution

1. Use an `env` block to pass the commit message to the shell safely
2. Add `head -1` to only extract the first PR number match (in case message body contains other `(#XXX)` patterns)

```yaml
env:
  COMMIT_MSG: ${{ github.event.head_commit.message }}
run: |
  PR_NUM=$(echo "$COMMIT_MSG" | grep -oP '\(#\K\d+(?=\))' | head -1)
```

## Test plan

- [ ] Merge this PR
- [ ] Verify deployment workflow extracts PR number correctly