### PR TITLE
[GHO-21] Update Grafana Alloy to v1.12.2

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -24,12 +24,12 @@ storage:
     # Quick hash retrieval:
     #   curl -s https://ghost-sysext-images.separationofconcerns.dev/alloy-{VERSION}-amd64.raw.sha256
     # ==========================================================================
-    - path: /opt/extensions/alloy/alloy-1.10.2-amd64.raw
+    - path: /opt/extensions/alloy/alloy-1.12.2-amd64.raw
       mode: 0644
       contents:
-        source: https://ghost-sysext-images.separationofconcerns.dev/alloy-1.10.2-amd64.raw
+        source: https://ghost-sysext-images.separationofconcerns.dev/alloy-1.12.2-amd64.raw
         verification:
-          hash: sha256-a0db1a966874eac9284dde47fb0cd917fdef22088701409f98d5e2e7fd70ae0f
+          hash: sha256-c43c25848b3ad0c970cd0ec77663b28f22dcf551d4da47da3cd82749819aefa9
 
     - path: /etc/systemd/system/ghost-compose.service
       mode: 0644
@@ -139,7 +139,7 @@ storage:
       hard: false
 
     # Symlink must be updated when changing Alloy version (path above)
-    - target: /opt/extensions/alloy/alloy-1.10.2-amd64.raw
+    - target: /opt/extensions/alloy/alloy-1.12.2-amd64.raw
       path: /etc/extensions/alloy.raw
       hard: false
 


### PR DESCRIPTION
## Summary

Update Grafana Alloy sysext from v1.10.2 to v1.12.2 (latest stable release).

## Changes

- Update Alloy sysext image path and URL to v1.12.2
- Update SHA256 verification hash
- Update symlink target

## Version Info

| Current | New |
|---------|-----|
| v1.10.2 | v1.12.2 |

**Release notes:** https://github.com/grafana/alloy/releases/tag/v1.12.2

## Notable Changes in v1.12.x

- Bug fixes for k8sattributes processor
- Database observability improvements
- Dependency updates for security

## Test Plan

- [ ] Verify `tofu plan` shows instance recreation (expected - Ignition change)
- [ ] Clean up old Tailscale device before applying
- [ ] After deployment, verify Alloy reports v1.12.2: `alloy --version`
- [ ] Verify metrics appear in Grafana Cloud
- [ ] Verify logs appear in Grafana Cloud
- [ ] Manually enable alloy.service if needed (known timing issue)