### PR TITLE
[GHO-21] Fix Alloy service autostart after sysext merge

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -255,8 +255,25 @@ systemd:
     - name: ghost-compose.service
       enabled: true
 
-    - name: alloy.service
+    # Alloy Enable Service
+    # The alloy.service comes from the sysext image, which isn't merged until
+    # systemd-sysext.service runs. Ignition's `enabled: true` doesn't work because
+    # it runs before sysext merge. This service enables Alloy after sysext is ready.
+    - name: alloy-enable.service
       enabled: true
+      contents: |
+        [Unit]
+        Description=Enable and start Alloy after sysext merge
+        After=systemd-sysext.service
+        Requires=systemd-sysext.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/systemctl enable --now alloy.service
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
 
     - name: update-engine.service
       enabled: true


### PR DESCRIPTION
## Summary

Fix the "known timing issue" where Alloy doesn't start automatically after instance creation.

## Problem

The `alloy.service` comes from the sysext image. Ignition's `enabled: true` runs before `systemd-sysext.service` merges the extensions, so the service file doesn't exist yet and the enable silently fails.

## Solution

Replace `alloy.service` with `alloy-enable.service` that:
- Runs **after** `systemd-sysext.service` completes
- Enables and starts `alloy.service`
- Uses `RemainAfterExit=yes` for proper state tracking

## Test Plan

- [ ] Deploy and verify `alloy.service` starts automatically (no manual intervention)
- [ ] Check `systemctl status alloy-enable.service` shows success
- [ ] Check `systemctl status alloy.service` shows active
- [ ] Verify metrics/logs appear in Grafana Cloud

## Notes

This resolves the issue documented in CLAUDE.md under "Updating Alloy Sysext Version" and removes the need for manual `sudo systemctl enable --now alloy.service` after deployment.