### PR TITLE
[GHO-21] Remove resolved Alloy timing issue note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,14 +396,6 @@ and only applied on first boot. This is the expected idempotent behavior.
 **Important:** Before recreating an instance, remove the old device from Tailscale admin
 to prevent naming conflicts. See `docs/runbooks/tailscale-device-cleanup.md` for details.
 
-**Known issue:** After instance recreation, `alloy.service` may not start automatically
-despite being configured as `enabled: true` in ghost.bu. This appears to be a timing issue
-where Ignition tries to enable the service before systemd-sysext merges the extension.
-If Alloy is not running after recreation, manually enable it:
-```bash
-sudo systemctl enable --now alloy.service
-```
-
 ### Updating Tailscale Sysext Version
 
 Tailscale is installed via systemd-sysext from the [Flatcar sysext-bakery](https://flatcar.github.io/sysext-bakery/tailscale/).


### PR DESCRIPTION
## Summary

Remove the "Known issue" note about Alloy not starting automatically, as this has been resolved by `alloy-enable.service` added in PR #110.

## Changes

- Remove the manual workaround instructions from CLAUDE.md

The `alloy-enable.service` now handles enabling Alloy after `systemd-sysext.service` completes, so manual intervention is no longer required.