### PR TITLE
fix: correct Tailscale sysext hash

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -127,7 +127,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/tailscale-v1.94.1-x86-64.raw
         verification:
-          hash: sha256-43425759a963728a5dcb1be4b1c87242badc334ad377c08117bf2c33b0bc14c1
+          hash: sha256-4fac074559d01328d0c59e030170821d22332a3ebd19087c135959f11feafaa1
 
     - path: /etc/sysupdate.tailscale.d/tailscale.conf
       contents:


### PR DESCRIPTION
## Summary

- Corrects the Tailscale sysext hash that was accidentally overwritten with the Alloy hash

## Problem

The alloy-sysext-build automation used a sed command that replaced ALL sha256 hashes in ghost.bu, not just the Alloy hash. This caused the Tailscale hash to be overwritten with the Alloy hash, leading to Ignition hash verification failures during deployment.

## Fix

- Wrong hash: `43425759a963728a5dcb1be4b1c87242badc334ad377c08117bf2c33b0bc14c1` (Alloy)
- Correct hash: `4fac074559d01328d0c59e030170821d22332a3ebd19087c135959f11feafaa1` (Tailscale)

## Related

- PR #24 in alloy-sysext-build fixes the automation to prevent this from happening again

## Test plan

- [ ] Merge this PR
- [ ] Run deploy-dev workflow manually
- [ ] Verify instance boots successfully with correct Tailscale sysext