### PR TITLE
docs: document path filtering behavior in CI workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,15 @@ docs/                   # Documentation
 
 ## CI/CD Workflows
 
-- **pr-tofu-fmt-check.yml**: Validates OpenTofu formatting on PRs
+- **pr-tofu-fmt-check.yml**: Validates OpenTofu formatting on feature branch pushes
+  - Only runs when infrastructure files are modified (path filtering)
 - **pr-tofu-plan-develop.yml**: Runs `tofu plan` on PRs to develop, uploads plan artifact
+  - Only runs when infrastructure files are modified (path filtering)
 - **deploy-dev.yml**: Deploys to dev environment on push to develop
   - Requires manual approval via GitHub environment protection
   - Compares PR plan artifact with current state (drift detection)
   - Runs health checks after deployment
+  - Skips deployment when no plan artifact exists (no infra changes in PR)
 
 ## Important Patterns
 


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md to document the new path filtering behavior in CI workflows

## Purpose

This is a **test PR for GHO-57** to verify that:
1. `pr-tofu-plan-develop.yml` skips the tofu plan when no infrastructure files are changed
2. The workflow shows "Skipped: No infrastructure files changed" status

**Expected behavior**: The PR workflow should detect that only `CLAUDE.md` was changed (not an infrastructure file) and skip the OpenTofu format check and plan jobs.

## Test plan

- [ ] Verify `pr-tofu-plan-develop.yml` workflow shows skipped status for tofu-plan job
- [ ] Verify status job shows "Skipped: No infrastructure files changed"