### PR TITLE
fix: add fetch-depth: 0 to path filtering checkout steps

### DIFF
--- a/.github/workflows/pr-tofu-fmt-check.yml
+++ b/.github/workflows/pr-tofu-fmt-check.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check for infrastructure file changes
         uses: dorny/paths-filter@v3

--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check for infrastructure file changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
## Summary

- Adds `fetch-depth: 0` to the checkout step in `changes` job for both workflow files

## Problem

The `dorny/paths-filter` action needs full git history to find the merge base between the PR branch and base branch. Without `fetch-depth: 0`, it falls back to direct commit comparison and shows a warning:

> "No merge base found - change detection will use direct <commit>..<commit> comparison"

This can cause incorrect change detection results.

## Solution

Add `fetch-depth: 0` to the checkout step in the `changes` job, similar to how it's already configured in other jobs that need full history.

## Test plan

- [ ] After merge, create a documentation-only PR and verify path filtering works correctly without the merge base warning