### PR TITLE
fix: add explicit base ref to paths-filter for proper change detection

### DIFF
--- a/.github/workflows/pr-tofu-fmt-check.yml
+++ b/.github/workflows/pr-tofu-fmt-check.yml
@@ -25,6 +25,8 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # For new branches, compare against develop (the branch features are created from)
+          base: develop
           filters: |
             infra:
               - 'opentofu/**/*.tofu'

--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -27,6 +27,8 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Use the PR's base branch for comparison
+          base: ${{ github.base_ref }}
           filters: |
             infra:
               - 'opentofu/**/*.tofu'


### PR DESCRIPTION
## Summary

Adds explicit `base` parameter to `dorny/paths-filter` action to ensure proper change detection:

- **pr-tofu-fmt-check.yml** (push trigger): Uses `develop` as base since feature branches are created from develop per repo convention
- **pr-tofu-plan-develop.yml** (pull_request trigger): Uses `${{ github.base_ref }}` to dynamically get the PR's target branch

## Problem

Without an explicit base reference, `dorny/paths-filter` may not correctly detect changed files, especially for new branches where there's no previous commit to compare against. This caused the "No merge base found" warning and incorrect change detection.

## Solution

Specify the base branch explicitly:
- For push events: hardcode `develop` (the branch features are created from)
- For pull_request events: use the dynamic `github.base_ref` for flexibility

## Test plan

- [ ] After merge, close and reopen test PR #123 to re-trigger workflows
- [ ] Verify no "No merge base found" warning
- [ ] Verify tofu-checks and tofu-plan jobs are skipped (not run) for doc-only changes