### PR TITLE
chore: add description to firewall_name variable

### DIFF
--- a/opentofu/envs/dev/variables.tofu
+++ b/opentofu/envs/dev/variables.tofu
@@ -4,7 +4,10 @@ variable "vultr_api_key" {
   sensitive   = true
 }
 
-variable "firewall_name" { type = string }
+variable "firewall_name" {
+  description = "Name for the Vultr firewall group"
+  type        = string
+}
 
 variable "admin_subnets" {
   description = "List of {subnet, subnet_size} objects allowed for SSH"


### PR DESCRIPTION
## Summary

- Adds a description to the `firewall_name` variable in `opentofu/envs/dev/variables.tofu`

## Purpose

This is a **test PR for GHO-57** to verify that:
1. `pr-tofu-fmt-check.yml` runs the format check when infrastructure files are changed
2. `pr-tofu-plan-develop.yml` runs the tofu plan when infrastructure files are changed

**Expected behavior**: Both workflows should detect the `.tofu` file change and run their respective jobs (not skip them).

## Test plan

- [ ] Verify `tofu-checks` job runs (not skipped)
- [ ] Verify `tofu-plan` job runs (not skipped)
- [ ] Verify both complete successfully