### PR TITLE
Configure systemd-sysupdate auto-updates for Alloy sysext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,26 +367,36 @@ Examples of valid branch names:
 The Grafana Alloy systemd-sysext image is built automatically by the
 [alloy-sysext-build](https://github.com/noahwhite/alloy-sysext-build) repository.
 
-**To update to a new version:**
+**Auto-updates:** Alloy auto-updates are enabled via systemd-sysupdate. When a new
+version is published to the R2 bucket, the system will automatically download and
+stage the update, flagging for reboot when updates are available.
 
-1. **Trigger a build** in alloy-sysext-build:
+**How auto-updates work:**
+1. A new Alloy release is detected by alloy-sysext-build's daily check workflow
+2. CI automatically builds and uploads the new sysext image to R2
+3. CI creates a PR in ghost-stack to update the pinned version in ghost.bu
+4. On the running instance, systemd-sysupdate checks R2 hourly for new versions
+5. If a newer version is found, it downloads and stages the update
+6. The system flags `/run/reboot-required` for the next reboot window
+
+**To manually pin a specific version:**
+
+1. **Trigger a build** in alloy-sysext-build (if not already built):
    - Create a GitHub release with the version tag (e.g., `v1.11.0`)
    - Or use workflow_dispatch with the version number
 
-2. **Wait for CI** to build and upload the image to R2
-
-3. **Get the SHA256 hash** from the build output or download the checksum file:
+2. **Get the SHA256 hash** from the build output or download the checksum file:
    ```bash
    curl -s https://ghost-sysext-images.separationofconcerns.dev/alloy-{VERSION}-amd64.raw.sha256
    ```
 
-4. **Update ghost.bu** (`opentofu/modules/vultr/instance/userdata/ghost.bu`):
+3. **Update ghost.bu** (`opentofu/modules/vultr/instance/userdata/ghost.bu`):
    - Update the file path: `/opt/extensions/alloy/alloy-{VERSION}-amd64.raw`
    - Update the source URL: `https://ghost-sysext-images.separationofconcerns.dev/alloy-{VERSION}-amd64.raw`
    - Update the hash: `sha256-{HASH}`
    - Update the symlink target in the `links` section
 
-5. **Apply infrastructure changes**:
+4. **Apply infrastructure changes**:
    ```bash
    ./opentofu/scripts/tofu.sh dev plan
    ./opentofu/scripts/tofu.sh dev apply

--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -14,12 +14,15 @@ storage:
     # This systemd-sysext image is built automatically by the alloy-sysext-build
     # repository: https://github.com/noahwhite/alloy-sysext-build
     #
-    # To update to a new Alloy version:
+    # Auto-updates are enabled via systemd-sysupdate (see dropin below).
+    # When a new version is published to the R2 bucket, sysupdate will
+    # automatically download and stage the update, flagging for reboot.
+    #
+    # Manual version pinning (if needed):
     #   1. Trigger a build in alloy-sysext-build (release or workflow_dispatch)
-    #   2. CI builds and uploads the new image to the R2 bucket
-    #   3. Get the SHA256 hash from the .sha256 file or build output
-    #   4. Update the path, source URL, and hash below
-    #   5. Apply infrastructure changes via OpenTofu
+    #   2. Update the path, source URL, and hash below
+    #   3. Update the symlink target in the links section
+    #   4. Apply infrastructure changes via OpenTofu
     #
     # Quick hash retrieval:
     #   curl -s https://ghost-sysext-images.separationofconcerns.dev/alloy-{VERSION}-amd64.raw.sha256
@@ -30,6 +33,25 @@ storage:
         source: https://ghost-sysext-images.separationofconcerns.dev/alloy-1.13.0-amd64.raw
         verification:
           hash: sha256-45761db339106677c3903fddb3be3ce11c90d69aceee49a8a9e94d8cdd06cc64
+
+    # Alloy sysupdate configuration for automatic updates
+    - path: /etc/sysupdate.alloy.d/alloy.conf
+      mode: 0644
+      contents:
+        inline: |
+          [Transfer]
+          Verify=false
+
+          [Source]
+          Type=url-file
+          Path=https://ghost-sysext-images.separationofconcerns.dev/
+          MatchPattern=alloy-@v-amd64.raw
+
+          [Target]
+          InstancesMax=3
+          Type=regular-file
+          Path=/opt/extensions/alloy/
+          CurrentSymlink=/etc/extensions/alloy.raw
 
     - path: /etc/systemd/system/ghost-compose.service
       mode: 0644
@@ -300,3 +322,10 @@ systemd:
             ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C tailscale update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/tailscale.raw > /tmp/tailscale-new.txt"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/tailscale.txt /tmp/tailscale-new.txt; then touch /run/reboot-required; fi"
+        - name: alloy.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/alloy.raw > /tmp/alloy.txt"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C alloy update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/alloy.raw > /tmp/alloy-new.txt"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/alloy.txt /tmp/alloy-new.txt; then touch /run/reboot-required; fi"


### PR DESCRIPTION
## Summary

- Adds sysupdate configuration to enable automatic updates for the Grafana Alloy sysext image
- When new versions are published to R2 by alloy-sysext-build, systemd-sysupdate will automatically download and stage updates
- System flags `/run/reboot-required` so locksmithd can coordinate reboots during the configured maintenance window

## Changes

### ghost.bu
- Added `/etc/sysupdate.alloy.d/alloy.conf` with URL source pointing to R2 bucket
- Added `alloy.conf` dropin for `systemd-sysupdate.service` to run Alloy update checks
- Updated comments to document auto-update behavior

### CLAUDE.md
- Updated "Updating Alloy Sysext Version" section to document auto-update workflow
- Added explanation of how auto-updates work end-to-end

## How it works

1. alloy-sysext-build's daily check workflow detects new Alloy releases
2. CI automatically builds and uploads new sysext image to R2
3. On the running instance, `systemd-sysupdate.timer` triggers hourly checks
4. sysupdate downloads `alloy-{VERSION}-amd64.raw` matching the `@v` pattern
5. Updates the symlink and flags for reboot
6. locksmithd reboots during the configured window (02:00-04:00)

## Security Note

Currently uses `Verify=false` (matches Flatcar sysext-bakery pattern). A follow-up story GHO-58 has been created to implement GPG signature verification.

## Test plan

- [x] PR checks pass (tofu fmt, tofu plan)
- [x] Verify sysupdate config syntax is valid
- [ ] After deployment, verify on instance:
  - `cat /etc/sysupdate.alloy.d/alloy.conf`
  - `systemctl cat systemd-sysupdate.service`
  - `systemd-sysupdate -C alloy list`

Closes GHO-55