### PR TITLE
fix: update Alloy sysext hash to match R2 file

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -32,7 +32,7 @@ storage:
       contents:
         source: https://ghost-sysext-images.separationofconcerns.dev/alloy-1.13.0-amd64.raw
         verification:
-          hash: sha256-45761db339106677c3903fddb3be3ce11c90d69aceee49a8a9e94d8cdd06cc64
+          hash: sha256-8f2e9da5ad9992b21b5dad4dfc90f47ea2451df223892db100ad38bfc89884f9
 
     # Alloy sysupdate configuration for automatic updates
     - path: /etc/sysupdate.alloy.d/alloy.conf


### PR DESCRIPTION
## Summary

Fixes Ignition hash verification failure during instance rebuild.

The SHA256 hash for `alloy-1.13.0-amd64.raw` in ghost.bu was stale and didn't match the current file on R2.

## Changes

| Field | Old | New |
|-------|-----|-----|
| Hash | `45761db339106677c3903fddb3be3ce11c90d69aceee49a8a9e94d8cdd06cc64` | `8f2e9da5ad9992b21b5dad4dfc90f47ea2451df223892db100ad38bfc89884f9` |

## Root cause

The Alloy sysext file on R2 was rebuilt (possibly due to a re-run of alloy-sysext-build CI), which changed the file's hash. The automated PR from alloy-sysext-build didn't update ghost.bu because the version number (1.13.0) remained the same.

## Test plan

- [ ] PR checks pass
- [ ] Instance rebuilds successfully with correct hash verification