### PR TITLE
Update Alloy 1.13.0 hash after GPG-signed rebuild

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -32,7 +32,7 @@ storage:
       contents:
         source: https://ghost-sysext-images.separationofconcerns.dev/alloy-1.13.0-amd64.raw
         verification:
-          hash: sha256-8f2e9da5ad9992b21b5dad4dfc90f47ea2451df223892db100ad38bfc89884f9
+          hash: sha256-b65c81da23cea7ea55f62c3fd9bffb032d675dfcc5d731cab00515273f7a5e2d
 
     # Alloy sysupdate configuration for automatic updates
     # GPG signature verification is enabled - signatures are created by


### PR DESCRIPTION
## Summary

Updates the Alloy sysext hash to match the latest GPG-signed build.

## Problem

After enabling GPG signing in alloy-sysext-build, a new artifact was built with a different hash. The automated PR creation was skipped because it only checks if the version changed, not if the hash changed.

## Changes

- Updates hash from `8f2e9da5...` to `b65c81da...`

## Root Cause

The `build-and-publish.yml` workflow has logic that skips PR creation when the version in ghost.bu matches the build version, even if the hash is different. A fix for this is in PR #36 in alloy-sysext-build.

## Test plan

- [ ] Merge this PR
- [ ] Deploy to dev environment
- [ ] Verify Ignition completes successfully (hash verification passes)
- [ ] Verify Alloy is running: `systemctl status alloy`
