### PR TITLE
feat: add console password for core user

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -1,6 +1,11 @@
 variant: flatcar
 version: 1.1.0
 
+passwd:
+  users:
+    - name: core
+      password_hash: "$6$bnxvJOYH0MHXZ53O$5lacL5CwhWuTH1FZqbtEWKppP2gODNIbFRuWG4sKC.iWnG2j0ZhNhFSQra.Cj7/wg1HR9F362dtArGSGmdL8B1"
+
 storage:
   filesystems:
     - device: /dev/vdb


### PR DESCRIPTION
## Summary

Enables console login for the `core` user when Tailscale is unavailable for debugging.

## Test plan

- [ ] Deploy to dev environment
- [ ] Access via Vultr console
- [ ] Login as `core` with the configured password
- [ ] Debug Tailscale/service failures