### PR TITLE
fix: create /var/mnt/storage/tinybird directory

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -275,6 +275,7 @@ systemd:
         mkdir -p /var/mnt/storage/mysql/data && chmod 0755 /var/mnt/storage/mysql/data && \
         mkdir -p /var/mnt/storage/ghost-compose && chmod 0700 /var/mnt/storage/ghost-compose && \
         mkdir -p /var/mnt/storage/traffic-analytics/data && chmod 0755 /var/mnt/storage/traffic-analytics/data && \
+        mkdir -p /var/mnt/storage/tinybird && chmod 0755 /var/mnt/storage/tinybird && \
         touch /var/mnt/storage/ghost-compose/.env.generated && chmod 0600 /var/mnt/storage/ghost-compose/.env.generated\'
         RemainAfterExit=true
         


### PR DESCRIPTION
## Summary

Add `/var/mnt/storage/tinybird` directory to `create-storage-dirs.service` so the tinybird-sync container has a volume mount target.

Without this, the tinybird-sync service fails because Docker can't mount to a non-existent directory.

## Test plan

- [ ] Deploy to dev environment
- [ ] Verify tinybird-provision.service completes successfully
- [ ] Verify `/var/mnt/storage/tinybird` contains synced files