### PR TITLE
fix: use replace_triggered_by for guaranteed Tailscale auth key replacement

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -30,9 +30,8 @@ resource "tailscale_tailnet_key" "this" {
   reusable      = false # One-time key - invalidated after first use for security
   ephemeral     = false
   preauthorized = true
-  # Include config hash in description for visibility in Tailscale admin
-  description = var.instance_config_hash != "" ? "ghost-dev-${substr(var.instance_config_hash, 0, 8)}" : "ghost-dev"
-  tags        = ["tag:ghost-dev"]
+  description   = "ghost-dev"
+  tags          = ["tag:ghost-dev"]
 
   lifecycle {
     # Explicitly replace this key whenever the instance config changes


### PR DESCRIPTION
## Summary

- Adds `null_resource.instance_config_trigger` with triggers based on `instance_config_hash`
- Adds `replace_triggered_by` lifecycle rule to `tailscale_tailnet_key` resource
- Adds `hashicorp/null` provider to the module

## Problem

The previous approach relied on changing the key description to trigger replacement, but the Tailscale provider may not detect description changes as requiring replacement. This caused the auth key to not be regenerated when the instance was recreated.

## Solution

Use OpenTofu's explicit `replace_triggered_by` lifecycle rule with a `null_resource` as the trigger. When the instance config hash changes (any userdata file modified), the null_resource is replaced, which explicitly triggers replacement of the auth key.

## Test plan

- [ ] Run `tofu plan` - should show null_resource and tailscale_tailnet_key will be created/replaced
- [ ] Deploy and verify new auth key is generated
- [ ] Verify instance authenticates with Tailscale successfully