### PR TITLE
fix: correct TinyBird tracker endpoint path

### DIFF
--- a/docker/ghost6/compose.yml
+++ b/docker/ghost6/compose.yml
@@ -38,7 +38,7 @@ services:
       database__connection__user: ${DATABASE_USER:-ghost}
       database__connection__password: ${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
-      tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
+      tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/v0/events
       tinybird__adminToken: ${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: ${TINYBIRD_WORKSPACE_ID:-}
       tinybird__tracker__datasource: analytics_events

--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
@@ -51,7 +51,7 @@ services:
       database__connection__password: $${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
       # TinyBird Analytics (enabled when TINYBIRD_ADMIN_TOKEN is in .env.secrets)
-      tinybird__tracker__endpoint: https://$${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
+      tinybird__tracker__endpoint: https://$${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/v0/events
       tinybird__adminToken: $${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: $${TINYBIRD_WORKSPACE_ID:-}
       tinybird__tracker__datasource: analytics_events


### PR DESCRIPTION
## Summary

- Changes Ghost's tracker endpoint from `/.ghost/analytics/api/v1/page_hit` to `/.ghost/analytics/v0/events`
- Updates both `compose.yml.tftpl` (production) and `docker/ghost6/compose.yml` (development)

## Problem

Web traffic analytics (page views) were returning 404 errors. The request flow:

1. Ghost sends tracking request to `/.ghost/analytics/api/v1/page_hit`
2. Caddy strips `/.ghost/analytics` prefix → `/api/v1/page_hit`
3. traffic-analytics receives `/api/v1/page_hit` but doesn't recognize it
4. Returns 404

## Solution

traffic-analytics proxies to TinyBird's Events API at `/v0/events`. Ghost's tracker endpoint must match this path structure so that after Caddy's rewrite, the path becomes `/v0/events`.

## Test plan

- [ ] Deploy changes
- [ ] Visit Ghost site in browser
- [ ] Check DevTools Network tab for `/.ghost/analytics/v0/events` requests
- [ ] Verify requests return 200 (not 404)
- [ ] Check Ghost Admin → Stats → Web traffic shows page views