### PR TITLE
fix: comprehensive hash for Tailscale key replacement trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,18 @@ the auth key and enable Tailscale SSH.
 `tofu apply` and is invalidated after first use. This prevents key reuse if exposed in
 OpenTofu state. See `docs/token-rotation-runbook.md` for details.
 
+**Auth Key Regeneration:** The Tailscale auth key is automatically regenerated whenever
+the instance would be replaced. This is controlled by `instance_replacement_hash` in
+`opentofu/envs/dev/main.tofu`, which hashes:
+- Instance attributes (region, plan, name, firewall_group_id, ssh key)
+- Userdata variables (domains, IPs, config values)
+- All config files in `opentofu/modules/vultr/instance/userdata/`
+
+**IMPORTANT:** When adding new config files to the instance userdata, you must also add
+them to the `instance_replacement_hash` calculation in `opentofu/envs/dev/main.tofu`.
+Otherwise, changes to those files won't trigger Tailscale key regeneration, and the
+new instance will fail to authenticate with an already-used key.
+
 **Important:** Changing the Tailscale version will recreate the instance. Before applying,
 remove the old device from Tailscale admin to prevent naming conflicts (e.g., the new
 instance being named `ghost-dev-01-1`). See `docs/runbooks/tailscale-device-cleanup.md`.

--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -68,6 +68,51 @@ data "terraform_remote_state" "bootstrap" {
 locals {
   # Use variable if provided (CI mode), otherwise read from bootstrap state (workstation mode)
   cloudflare_zone_id = var.cloudflare_zone_id != "" ? var.cloudflare_zone_id : data.terraform_remote_state.bootstrap[0].outputs.cloudflare_zone_id
+
+  # ==========================================================================
+  # Instance Replacement Hash
+  # ==========================================================================
+  # This hash captures all inputs that would cause the Vultr instance to be
+  # replaced. When any of these change, the Tailscale auth key is also
+  # regenerated to ensure the new instance can authenticate.
+  #
+  # Includes:
+  # - Instance attributes (region, plan, name, firewall, ssh key)
+  # - Userdata variables (domains, IPs, config values)
+  # - Template/config files that compose the Ignition userdata
+  instance_replacement_hash = sha256(jsonencode({
+    # Instance attributes that force replacement
+    region            = var.instance_region
+    plan              = var.instance_plan
+    name              = var.instance_name
+    firewall_group_id = module.fw.id
+    ssh_key_name      = var.ssh_key_name
+    ssh_public_key    = var.ssh_public_key
+
+    # Userdata variables
+    ghost_url          = var.ghost_url
+    ghost_domain       = var.ghost_domain
+    ghost_admin_domain = var.ghost_admin_domain
+    admin_ip           = var.admin_ip
+    mail_smtp_user     = var.mail_smtp_user
+    locksmith_mask     = var.locksmith_mask
+
+    # Template and config file hashes (changes to these rebuild userdata)
+    files = {
+      ghost_bu              = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost.bu")
+      ghost_compose_service = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose.service")
+      tinybird_provision    = filesha256("${path.module}/../../modules/vultr/instance/userdata/tinybird-provision.sh")
+      compose_yml           = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl")
+      env_config            = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/env.config.tftpl")
+      caddyfile             = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile")
+      caddy_activitypub     = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/caddy/snippets/ActivityPub")
+      caddy_logging         = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/caddy/snippets/Logging")
+      caddy_security        = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/caddy/snippets/SecurityHeaders")
+      caddy_analytics       = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/caddy/snippets/TrafficAnalytics")
+      mysql_init            = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/mysql-init/create-multiple-databases.sh")
+      tinybird_dockerfile   = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost-compose/tinybird/Dockerfile")
+    }
+  }))
 }
 
 module "grafana-cloud" {
@@ -85,9 +130,9 @@ module "pagerduty" {
 module "tailscale" {
   source = "../../modules/tailscale"
 
-  # Trigger auth key regeneration when instance config changes
+  # Trigger auth key regeneration when instance will be replaced
   # This ensures a fresh one-time key is created when the instance is recreated
-  instance_config_hash = filesha256("${path.module}/../../modules/vultr/instance/userdata/ghost.bu")
+  instance_replacement_hash = local.instance_replacement_hash
 }
 
 module "dns_records" {

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -11,18 +11,18 @@ terraform {
   }
 }
 
-variable "instance_config_hash" {
+variable "instance_replacement_hash" {
   type        = string
-  description = "Hash of instance configuration that triggers auth key regeneration when instance is recreated"
+  description = "Hash of all inputs that would cause instance replacement, triggering auth key regeneration"
   default     = ""
 }
 
-# Trigger resource for instance config changes
-# When any userdata file changes, this resource is replaced, which in turn
-# triggers replacement of the auth key via replace_triggered_by
-resource "null_resource" "instance_config_trigger" {
+# Trigger resource for instance replacement
+# When any input that would cause instance replacement changes, this resource
+# is replaced, which in turn triggers replacement of the auth key
+resource "null_resource" "instance_replacement_trigger" {
   triggers = {
-    config_hash = var.instance_config_hash
+    replacement_hash = var.instance_replacement_hash
   }
 }
 
@@ -34,9 +34,9 @@ resource "tailscale_tailnet_key" "this" {
   tags          = ["tag:ghost-dev"]
 
   lifecycle {
-    # Explicitly replace this key whenever the instance config changes
+    # Explicitly replace this key whenever the instance would be replaced
     # This guarantees a fresh one-time key when the instance is recreated
-    replace_triggered_by = [null_resource.instance_config_trigger]
+    replace_triggered_by = [null_resource.instance_replacement_trigger]
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces single-file hash with comprehensive hash of all instance replacement triggers
- Renamed `instance_config_hash` to `instance_replacement_hash` for clarity
- Hash now includes instance attributes, userdata variables, and all config files

## Problem

The previous approach only hashed `ghost.bu`, so changes to other files (like `compose.yml.tftpl` in PR #144) didn't trigger Tailscale key regeneration. This caused the instance to be recreated with an already-used (invalid) auth key.

## Solution

The new `instance_replacement_hash` captures ALL inputs that would cause instance replacement:

**Instance attributes:**
- region, plan, name, firewall_group_id, ssh_key_name, ssh_public_key

**Userdata variables:**
- ghost_url, ghost_domain, ghost_admin_domain, admin_ip, mail_smtp_user, locksmith_mask

**Config files (12 total):**
- ghost.bu, ghost-compose.service, tinybird-provision.sh
- compose.yml.tftpl, env.config.tftpl
- Caddyfile and all snippets
- mysql-init script, tinybird Dockerfile

When any of these change, the `null_resource.instance_replacement_trigger` is replaced, which triggers `tailscale_tailnet_key` replacement via `replace_triggered_by`.

## Test plan

- [ ] Run `tofu plan` - should show `null_resource.instance_replacement_trigger` being replaced (hash changed)
- [ ] Run `tofu plan` - should show `tailscale_tailnet_key.this` being replaced (due to replace_triggered_by)
- [ ] Deploy and verify new auth key is generated
- [ ] Verify instance authenticates with Tailscale successfully