### PR TITLE
Fix TrafficAnalytics not working on main domain

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
@@ -8,6 +8,9 @@
 
     tls /certs/cloudflare-origin.crt /certs/cloudflare-origin.key
 
+    # Traffic Analytics service (proxies /.ghost/analytics/* to traffic-analytics container)
+    import snippets/TrafficAnalytics
+
     # Health check authentication via token header
     # Token is sourced from .env.secrets via Docker Compose env_file
     @health_check {


### PR DESCRIPTION
## Summary

- Add `import snippets/TrafficAnalytics` to the main `{$DOMAIN}` block in Caddyfile
- Analytics requests are sent to the main domain (separationofconcerns.dev), not the admin domain
- Without this import, `/.ghost/analytics/*` requests were falling through to Ghost and returning 404
- **Also**: Add `opentofu/**/userdata/**` to workflow path filters so changes to static config files (like Caddyfile) trigger the tofu plan workflow

## Test plan

- [ ] Verify CI plan workflow runs for this PR (tests the path filter fix)
- [ ] Deploy and verify analytics requests reach traffic-analytics container
- [ ] Check traffic-analytics logs show incoming requests when browsing the site
- [ ] Verify Ghost Stats dashboard shows page views