### PR TITLE
Add userdata/** to workflow path filters

### DIFF
--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -35,6 +35,7 @@ jobs:
               - 'opentofu/**/*.bu'
               - 'opentofu/**/*.tftpl'
               - 'opentofu/**/*.sh'
+              - 'opentofu/**/userdata/**'
               - 'docker/scripts/**'
               - '.github/workflows/pr-tofu-*.yml'
               - '.github/workflows/deploy-dev.yml'


### PR DESCRIPTION
## Summary

- Add `opentofu/**/userdata/**` to the path filters in `pr-tofu-plan-develop.yml`
- Changes to static config files (like Caddyfile, Caddy snippets, mysql-init scripts) weren't triggering the tofu plan workflow
- These files affect infrastructure via `instance_replacement_hash` and are deployed via Ignition

## Test plan

- [ ] Verify this PR triggers the tofu plan workflow (it modifies a workflow file which is already in the filter)
- [ ] Future PRs that only modify userdata files should trigger plans