### PR TITLE
Fix TrafficAnalytics to rewrite to /api/v1/page_hit

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/TrafficAnalytics
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/TrafficAnalytics
@@ -1,6 +1,7 @@
-# Proxy analytics requests with any prefix (e.g. /.ghost/analytics/ or /blog/.ghost/analytics/)
-@analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
+# Proxy analytics requests to traffic-analytics service
+# traffic-analytics expects POST /api/v1/page_hit
+@analytics_paths path /.ghost/analytics/*
 handle @analytics_paths {
-    rewrite * {re.analytics_match.2}
+    rewrite * /api/v1/page_hit
     reverse_proxy traffic-analytics:3000
 }


### PR DESCRIPTION
## Summary

- Fix Ghost tracker endpoint to use `/api/v1/page_hit` path (matches what traffic-analytics expects)
- Keep TrafficAnalytics Caddy snippet matching the [official ghost-docker repo](https://github.com/TryGhost/ghost-docker/blob/main/caddy/snippets/TrafficAnalytics)
- The Caddy snippet rewrites `/.ghost/analytics/api/v1/page_hit` → `/api/v1/page_hit`
- Update both `compose.yml.tftpl` and `docker/ghost6/compose.yml`

## Test plan

- [ ] Verify tofu plan runs (tests the userdata path filter from PR #149)
- [ ] Deploy and verify traffic-analytics receives requests at `/api/v1/page_hit`
- [ ] Check traffic-analytics logs show successful 2xx responses
- [ ] Verify Ghost Stats dashboard shows page views