### PR TITLE
Fix TrafficAnalytics: use official snippet, fix tracker endpoint

### DIFF
--- a/docker/ghost6/compose.yml
+++ b/docker/ghost6/compose.yml
@@ -38,7 +38,7 @@ services:
       database__connection__user: ${DATABASE_USER:-ghost}
       database__connection__password: ${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
-      tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/v0/events
+      tinybird__tracker__endpoint: https://${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
       tinybird__adminToken: ${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: ${TINYBIRD_WORKSPACE_ID:-}
       tinybird__tracker__datasource: analytics_events

--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/TrafficAnalytics
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/TrafficAnalytics
@@ -1,7 +1,6 @@
-# Proxy analytics requests to traffic-analytics service
-# traffic-analytics expects POST /api/v1/page_hit
-@analytics_paths path /.ghost/analytics/*
+# Proxy analytics requests with any prefix (e.g. /.ghost/analytics/ or /blog/.ghost/analytics/)
+@analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
 handle @analytics_paths {
-    rewrite * /api/v1/page_hit
+    rewrite * {re.analytics_match.2}
     reverse_proxy traffic-analytics:3000
 }

--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
@@ -51,7 +51,7 @@ services:
       database__connection__password: $${DATABASE_PASSWORD:?DATABASE_PASSWORD environment variable is required}
       database__connection__database: ghost
       # TinyBird Analytics (enabled when TINYBIRD_ADMIN_TOKEN is in .env.secrets)
-      tinybird__tracker__endpoint: https://$${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/v0/events
+      tinybird__tracker__endpoint: https://$${DOMAIN:?DOMAIN environment variable is required}/.ghost/analytics/api/v1/page_hit
       tinybird__adminToken: $${TINYBIRD_ADMIN_TOKEN:-}
       tinybird__workspaceId: $${TINYBIRD_WORKSPACE_ID:-}
       tinybird__tracker__datasource: analytics_events


### PR DESCRIPTION
## Summary

PR #150 had the wrong fix (modifying the Caddy snippet). This PR fixes it correctly:

- Revert TrafficAnalytics Caddy snippet to match [official ghost-docker](https://github.com/TryGhost/ghost-docker/blob/main/caddy/snippets/TrafficAnalytics)
- Fix Ghost tracker endpoint to `/.ghost/analytics/api/v1/page_hit` (matches [official compose.yml](https://github.com/TryGhost/ghost-docker/blob/main/compose.yml))
- Caddy rewrites `/.ghost/analytics/api/v1/page_hit` → `/api/v1/page_hit`
- traffic-analytics receives at `/api/v1/page_hit` and forwards to TinyBird `/v0/events`

## Test plan

- [ ] Deploy and verify traffic-analytics logs show 2xx responses (not 404)
- [ ] Verify Ghost Stats dashboard shows page views