### PR TITLE
Trigger instance recreation after manual deletion

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -1,3 +1,4 @@
+# Dev environment - Ghost blog infrastructure
 terraform {
   backend "s3" {}
   required_providers {


### PR DESCRIPTION
## Summary

Instance was manually deleted in Vultr console to resolve a block storage region mismatch issue (block storage was in New York, instance was being created in New Jersey).

This PR triggers a fresh tofu plan which will detect the missing instance and plan to recreate it.

## Test plan

- [ ] Verify tofu plan shows instance will be created
- [ ] Merge and verify deploy workflow recreates the instance
- [ ] Verify block storage attaches successfully
- [ ] Verify Ghost site is accessible