### PR TITLE
chore: retrigger OpenTofu plan for GHO-59 deployment

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -1,5 +1,6 @@
 variant: flatcar
 version: 1.1.0
+# GHO-59: SHA256SUMS manifest support for systemd-sysupdate
 
 passwd:
   users:


### PR DESCRIPTION
## Summary

Trivial change to retrigger OpenTofu plan workflow after drift was detected during deployment.

## Context

The previous deployment partially failed due to block storage mount issues, causing state drift. This PR generates a fresh plan artifact that accounts for the current state.

## Changes

- Added comment to ghost.bu header

## Related

- GHO-59