### PR TITLE
fix: move sysupdate-merge-keyring.sh to /opt/bin

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -102,7 +102,7 @@ storage:
 
     # Script to merge system GPG keyring with Alloy signing key
     # Checks for .pgp (newer systemd) first, then falls back to .gpg (legacy)
-    - path: /usr/local/bin/sysupdate-merge-keyring.sh
+    - path: /opt/bin/sysupdate-merge-keyring.sh
       mode: 0755
       contents:
         inline: |
@@ -480,7 +480,7 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/local/bin/sysupdate-merge-keyring.sh
+        ExecStart=/opt/bin/sysupdate-merge-keyring.sh
         RemainAfterExit=yes
 
         [Install]


### PR DESCRIPTION
## Summary

Move `sysupdate-merge-keyring.sh` from `/usr/local/bin/` to `/opt/bin/`.

## Problem

`/usr` is read-only on Flatcar Container Linux (verity-protected immutable partition). The previous path caused Ignition to fail when trying to create the script.

## Solution

Use `/opt/bin/` which is on the writable root filesystem and is the conventional location for custom executables on Flatcar.

## Related

- GHO-59