### PR TITLE
chore: retrigger deploy after block storage failure

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -1,6 +1,6 @@
 variant: flatcar
 version: 1.1.0
-# GHO-59: SHA256SUMS manifest support for systemd-sysupdate
+# GHO-59: SHA256SUMS manifest and GPG keyring merge for systemd-sysupdate
 
 passwd:
   users:


### PR DESCRIPTION
## Summary

Stub PR to retrigger OpenTofu plan after block storage mount failure caused drift.

## Related

- GHO-59