### PR TITLE
fix: pass TF_VAR_admin_ip to container in infra-shell.sh

### DIFF
--- a/docker/scripts/infra-shell.sh
+++ b/docker/scripts/infra-shell.sh
@@ -350,6 +350,7 @@ if [[ "$RUN_CONTAINER" == "true" ]]; then
     -e TF_VAR_cloudflare_api_token \
     -e TF_VAR_ssh_public_key \
     -e TF_VAR_admin_subnets \
+    -e TF_VAR_admin_ip \
     -e R2_ACCESS_KEY_ID \
     -e R2_SECRET_ACCESS_KEY \
     -e TAILSCALE_API_KEY \


### PR DESCRIPTION
## Summary

- Pass `TF_VAR_admin_ip` environment variable to the docker container

## Problem

The `infra-shell.sh` script correctly fetches and exports `TF_VAR_admin_ip` (line 287/299), but the `docker run` command was missing the `-e TF_VAR_admin_ip` flag. This caused `tofu plan` to prompt for `var.admin_ip` when running inside the container.

## Fix

Added `-e TF_VAR_admin_ip \` to the docker run command alongside the other `TF_VAR_*` variables.

## Test plan

- [ ] Run `./docker/scripts/infra-shell.sh` locally
- [ ] Inside container, verify `echo $TF_VAR_admin_ip` shows the IP
- [ ] Run `./opentofu/scripts/tofu.sh dev plan` without prompts

Fixes GHO-60