### PR TITLE
Rewrite secrets-management.md to reflect Bitwarden-based workflow

### DIFF
--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -124,12 +124,3 @@ Vultr does not support scoped or expiring API tokens. The account uses a single 
 ---
 
 📁 _This document lives at `docs/secrets-management.md` in the repository._
-=======
----
-
-## Application Secrets (Infisical)
-
-Ghost application secrets (database passwords, health check token, mail password, TinyBird token) are managed in **Infisical**, not Bitwarden or 1Password. Infisical is provisioned via OpenTofu and instances fetch secrets at boot using a scoped machine identity.
-
-See [Infisical Secret Provisioning and Rotation](./runbooks/infisical-secrets.md) for the full provisioning and rotation procedures.
-


### PR DESCRIPTION
## Summary

- Removes all stale references to 1Password and the old manual copy-paste workflow from the MVP era
- Rewrites the document to describe the current three-layer secrets architecture:
  - **Bitwarden Secrets Manager** — infrastructure credentials retrieved via `bws` CLI in `infra-shell.sh`
  - **GitHub Secrets** — CI/CD-only values (admin IP, zone IDs, health check token)
  - **Infisical** — application secrets, with Token Auth boot-time delivery (GHO-74/75/76)
- Adds full Bitwarden UUID reference table matching `infra-shell.sh`
- Retains the Vultr API key limitations section (still accurate)

## Test plan

- [ ] Read through and confirm all Bitwarden UUIDs match `infra-shell.sh`
- [ ] Confirm GitHub Secrets table matches actual environment configuration
- [ ] Confirm Infisical section is consistent with `docs/runbooks/infisical-secrets.md`