### PR TITLE
chore: retrigger plan after Infisical workflow fix

### DIFF
--- a/opentofu/modules/infisical/main.tofu
+++ b/opentofu/modules/infisical/main.tofu
@@ -76,3 +76,4 @@ resource "infisical_project_identity_specific_privilege" "ghost_dev_read_env" {
     }
   ]
 }
+


### PR DESCRIPTION
Triggers a fresh `tofu plan` to clear the drift detection failure on the previous deployment.

The prior PR (#180) had a workflow fix committed after the plan was generated, causing the deploy workflow to detect drift and abort. This PR generates a clean plan against the current state.