### PR TITLE
fix: add depends_on to prevent privilege race condition

### DIFF
--- a/opentofu/modules/infisical/main.tofu
+++ b/opentofu/modules/infisical/main.tofu
@@ -57,6 +57,9 @@ resource "infisical_project_identity_specific_privilege" "ghost_dev_read_env" {
   project_slug = infisical_project.ghost.slug
   identity_id  = infisical_identity.ghost_dev.id
 
+  # Must wait for project membership to be established before granting privileges
+  depends_on = [infisical_project_identity.ghost_dev]
+
   permissions_v2 = [
     {
       action  = ["read"]


### PR DESCRIPTION
## Summary

- Fixes a race condition where `infisical_project_identity_specific_privilege` was being created in parallel with `infisical_project_identity`, causing a 403 from the Infisical API ("You are not a member of this project")
- The privilege resource references `infisical_project.ghost.slug` and `infisical_identity.ghost_dev.id`, neither of which come from the membership resource — so OpenTofu had no implicit dependency and parallelised the two creates
- Adding `depends_on = [infisical_project_identity.ghost_dev]` ensures membership is fully established before privilege assignment is attempted

## Test plan

- [ ] PR plan completes without errors
- [ ] `tofu apply` creates all Infisical resources in the correct order (membership before privilege)
- [ ] No 403 errors from the Infisical API