### PR TITLE
fix: add project admin user and remove secretPath from allow policy

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -198,4 +198,5 @@ module "infisical" {
 
   org_id      = var.infisical_org_id
   environment = "dev"
+  admin_email = "noah@noahwhite.net"
 }

--- a/opentofu/envs/dev/tests/infisical.tofutest.hcl
+++ b/opentofu/envs/dev/tests/infisical.tofutest.hcl
@@ -28,6 +28,12 @@ mock_provider "infisical" {
   mock_resource "infisical_project_identity_specific_privilege" {
     defaults = {}
   }
+
+  mock_resource "infisical_project_user" {
+    defaults = {
+      membership_id = "test-user-membership-id"
+    }
+  }
 }
 
 run "infisical_identity_is_single_use" {
@@ -42,7 +48,8 @@ run "infisical_identity_is_single_use" {
   }
 
   variables {
-    org_id = "test-org-id"
+    org_id      = "test-org-id"
+    admin_email = "noah@noahwhite.net"
   }
 
   assert {
@@ -73,7 +80,8 @@ run "infisical_project_configuration" {
   }
 
   variables {
-    org_id = "test-org-id"
+    org_id      = "test-org-id"
+    admin_email = "noah@noahwhite.net"
   }
 
   assert {
@@ -84,6 +92,11 @@ run "infisical_project_configuration" {
   assert {
     condition     = infisical_project.ghost.slug == "ghost-stack"
     error_message = "Project slug should be 'ghost-stack'"
+  }
+
+  assert {
+    condition     = infisical_project_user.admin.roles[0].role_slug == "admin"
+    error_message = "Human admin must have 'admin' project role"
   }
 }
 
@@ -99,7 +112,8 @@ run "infisical_identity_configuration" {
   }
 
   variables {
-    org_id = "test-org-id"
+    org_id      = "test-org-id"
+    admin_email = "noah@noahwhite.net"
   }
 
   assert {
@@ -132,12 +146,18 @@ run "infisical_privilege_scoped_to_dev" {
   variables {
     org_id      = "test-org-id"
     environment = "dev"
+    admin_email = "noah@noahwhite.net"
   }
 
-  # Allow policy: read access scoped to target environment
+  # Allow policy: read access scoped to target environment only
   assert {
     condition     = strcontains(infisical_project_identity_specific_privilege.ghost_dev_read_env.permissions_v2[0].conditions, "\"$eq\"")
     error_message = "Allow policy must use $eq operator to scope to the target environment"
+  }
+
+  assert {
+    condition     = !strcontains(infisical_project_identity_specific_privilege.ghost_dev_read_env.permissions_v2[0].conditions, "secretPath")
+    error_message = "Allow policy must not restrict by secretPath (all paths in env should be readable)"
   }
 
   assert {

--- a/opentofu/modules/infisical/main.tofu
+++ b/opentofu/modules/infisical/main.tofu
@@ -53,6 +53,23 @@ resource "infisical_project_identity" "ghost_dev" {
 # Two policies:
 #   1. Allow read in the target environment at root path
 #   2. Forbid all actions in any other environment (explicit deny — defence in depth)
+# ==========================================================================
+# Project Admin User
+#
+# Ensures the human admin is added as a project administrator.
+# Without this, the project is only accessible to the provisioner machine
+# identity and requires a manual "Join as Admin" step in the Infisical UI.
+# ==========================================================================
+
+resource "infisical_project_user" "admin" {
+  project_id = infisical_project.ghost.id
+  username   = var.admin_email
+
+  roles = [{
+    role_slug = "admin"
+  }]
+}
+
 resource "infisical_project_identity_specific_privilege" "ghost_dev_read_env" {
   project_slug = infisical_project.ghost.slug
   identity_id  = infisical_identity.ghost_dev.id
@@ -66,7 +83,6 @@ resource "infisical_project_identity_specific_privilege" "ghost_dev_read_env" {
       subject = "secrets"
       conditions = jsonencode({
         "environment" = { "$eq" = var.environment }
-        "secretPath"  = { "$eq" = "/" }
       })
     },
     {

--- a/opentofu/modules/infisical/variables.tofu
+++ b/opentofu/modules/infisical/variables.tofu
@@ -8,3 +8,8 @@ variable "environment" {
   type        = string
   default     = "dev"
 }
+
+variable "admin_email" {
+  description = "Email of the human admin user to add as project administrator"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Adds `infisical_project_user` resource to automatically grant the human admin (`noah@noahwhite.net`) admin access to the Ghost Stack project. Without this, the project is only accessible to the provisioner machine identity and requires a manual "Join as Admin" step in the Infisical UI after each `tofu apply`.
- Removes the `secretPath = /` condition from the allow policy. The POC did not have this restriction and it was unnecessarily narrow — all paths in the target environment should be readable.

## Test plan

- [ ] PR plan succeeds
- [ ] `tofu apply` creates `infisical_project_user.admin` and the human admin appears as a project member without needing to manually join
- [ ] Allow policy conditions contain only the environment `$eq` filter, no `secretPath`