### PR TITLE
feat(infisical): generate single-use boot token per instance replacement (GHO-75)

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -182,6 +182,8 @@ module "vm" {
   ghost_admin_domain = var.ghost_admin_domain
   admin_ip           = var.admin_ip
   mail_smtp_user     = var.mail_smtp_user
+
+  infisical_boot_token = module.infisical.ghost_dev_boot_token
 }
 
 module "block_storage" {
@@ -196,7 +198,8 @@ module "block_storage" {
 module "infisical" {
   source = "../../modules/infisical"
 
-  org_id      = var.infisical_org_id
-  environment = "dev"
-  admin_email = "noah@noahwhite.net"
+  org_id                    = var.infisical_org_id
+  environment               = "dev"
+  admin_email               = "noah@noahwhite.net"
+  instance_replacement_hash = local.instance_replacement_hash
 }

--- a/opentofu/envs/dev/tests/infisical.tofutest.hcl
+++ b/opentofu/envs/dev/tests/infisical.tofutest.hcl
@@ -1,4 +1,14 @@
+mock_provider "null" {}
+
 mock_provider "infisical" {
+  mock_resource "infisical_identity_token_auth_token" {
+    defaults = {
+      token          = "mock-boot-token"
+      is_revoked     = false
+      number_of_uses = 0
+    }
+  }
+
   mock_resource "infisical_project" {
     defaults = {
       id           = "test-project-id"
@@ -58,13 +68,18 @@ run "infisical_identity_is_single_use" {
   }
 
   assert {
-    condition     = infisical_identity_token_auth.ghost_dev.access_token_ttl == 300
-    error_message = "Boot-time identity token TTL must be 300 seconds (5 minutes)"
+    condition     = infisical_identity_token_auth.ghost_dev.access_token_ttl == 900
+    error_message = "Boot-time identity token TTL must be 900 seconds (15 minutes) to cover apply + boot window"
   }
 
   assert {
-    condition     = infisical_identity_token_auth.ghost_dev.access_token_max_ttl == 300
-    error_message = "Boot-time identity max token TTL must be capped at 300 seconds at the method level"
+    condition     = infisical_identity_token_auth.ghost_dev.access_token_max_ttl == 900
+    error_message = "Boot-time identity max token TTL must be capped at 900 seconds at the method level"
+  }
+
+  assert {
+    condition     = output.ghost_dev_boot_token != ""
+    error_message = "ghost_dev_boot_token output must be set"
   }
 }
 

--- a/opentofu/modules/infisical/main.tofu
+++ b/opentofu/modules/infisical/main.tofu
@@ -4,6 +4,10 @@ terraform {
       source  = "infisical/infisical"
       version = "~> 0.16"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
 }
 
@@ -33,8 +37,27 @@ resource "infisical_identity" "ghost_dev" {
 resource "infisical_identity_token_auth" "ghost_dev" {
   identity_id                 = infisical_identity.ghost_dev.id
   access_token_num_uses_limit = 1   # single-use — token consumed on first use
-  access_token_ttl            = 300 # 5 minutes — enough to survive boot window
-  access_token_max_ttl        = 300 # cap max TTL at method level
+  access_token_ttl            = 900 # 15 minutes — covers tofu apply + instance boot window
+  access_token_max_ttl        = 900 # cap max TTL at method level
+}
+
+resource "null_resource" "instance_replacement_trigger" {
+  triggers = {
+    replacement_hash = var.instance_replacement_hash
+  }
+}
+
+resource "infisical_identity_token_auth_token" "ghost_dev_boot" {
+  identity_id = infisical_identity.ghost_dev.id
+  name        = "ghost-dev-boot"
+
+  depends_on = [infisical_identity_token_auth.ghost_dev]
+
+  lifecycle {
+    # Regenerate token only when the instance is being replaced.
+    # Mirrors the pattern used in modules/tailscale for the auth key.
+    replace_triggered_by = [null_resource.instance_replacement_trigger]
+  }
 }
 
 # Link identity to project with no-access project role.

--- a/opentofu/modules/infisical/outputs.tofu
+++ b/opentofu/modules/infisical/outputs.tofu
@@ -12,3 +12,9 @@ output "ghost_dev_identity_id" {
   description = "Machine identity ID for ghost-dev. Note: the Universal Auth client ID is a separate value found in the Universal Auth tab in the Infisical console."
   value       = infisical_identity.ghost_dev.id
 }
+
+output "ghost_dev_boot_token" {
+  description = "Single-use boot token for the ghost-dev instance (consumed once at first boot)"
+  value       = infisical_identity_token_auth_token.ghost_dev_boot.token
+  sensitive   = true
+}

--- a/opentofu/modules/infisical/variables.tofu
+++ b/opentofu/modules/infisical/variables.tofu
@@ -13,3 +13,9 @@ variable "admin_email" {
   description = "Email of the human admin user to add as project administrator"
   type        = string
 }
+
+variable "instance_replacement_hash" {
+  type        = string
+  description = "Hash of all inputs that would cause instance replacement, triggering boot token regeneration"
+  default     = ""
+}

--- a/opentofu/modules/vultr/instance/main.tofu
+++ b/opentofu/modules/vultr/instance/main.tofu
@@ -52,6 +52,9 @@ locals {
   # TinyBird Analytics provisioning
   ghost_tinybird_dockerfile = filebase64("${path.module}/userdata/ghost-compose/tinybird/Dockerfile")
   tinybird_provision_script = filebase64("${path.module}/userdata/tinybird-provision.sh")
+
+  # Infisical boot token (base64-encoded for Ignition data URI)
+  infisical_boot_token_b64 = base64encode(var.infisical_boot_token)
 }
 
 # (The data source will fail if not exists; so we just create the resource unconditionally.)
@@ -79,6 +82,9 @@ data "ct_config" "ghost" {
     # TinyBird Analytics provisioning
     ghost_tinybird_dockerfile = local.ghost_tinybird_dockerfile
     tinybird_provision_script = local.tinybird_provision_script
+
+    # Infisical boot token
+    infisical_boot_token_b64 = local.infisical_boot_token_b64
   })
   strict = true
 }

--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -249,6 +249,18 @@ storage:
       contents:
         source: "data:text/plain;charset=utf-8;base64,${tinybird_provision_script}"
 
+    # ==========================================================================
+    # Infisical Boot-Time Access Token (GHO-75)
+    # ==========================================================================
+    # Single-use Token Auth credential for boot-time secret fetching (GHO-76).
+    # Generated per-instance-replacement by OpenTofu and injected via Ignition.
+    # Consumed once at first boot; token is invalid after use.
+    # ==========================================================================
+    - path: /etc/infisical/access-token
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,${infisical_boot_token_b64}"
+
     - path: /etc/locksmith/locksmith.conf
       mode: 0644
       overwrite: true

--- a/opentofu/modules/vultr/instance/variables.tofu
+++ b/opentofu/modules/vultr/instance/variables.tofu
@@ -90,3 +90,9 @@ variable "mail_smtp_user" {
   description = "SMTP username for transactional email"
   type        = string
 }
+
+variable "infisical_boot_token" {
+  description = "Single-use Infisical access token for boot-time secret fetching via Token Auth"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- Adds `infisical_identity_token_auth_token` resource to the infisical module, following the same `null_resource` + `lifecycle.replace_triggered_by` pattern as the Tailscale auth key
- A fresh single-use token is generated by OpenTofu at apply time whenever `instance_replacement_hash` changes (i.e., only when the instance is being replaced)
- Token is delivered to `/etc/infisical/access-token` (mode `0600`) via Ignition as a base64 data URI — consumed once at first boot for GHO-76's secrets fetch
- Token Auth TTL increased 300s → 900s to cover the full apply + Vultr provisioning + boot window (~10 min actual, 15 min margin)
- No changes to `infra-shell.sh` or CI workflows — the provider handles everything; break-glass works via normal `tofu apply`

## Files changed

| File | Change |
|------|--------|
| `modules/infisical/main.tofu` | Add `null` provider, `null_resource` trigger, `infisical_identity_token_auth_token.ghost_dev_boot`; update TTL 300s → 900s |
| `modules/infisical/variables.tofu` | Add `instance_replacement_hash` variable |
| `modules/infisical/outputs.tofu` | Add `ghost_dev_boot_token` sensitive output |
| `modules/vultr/instance/variables.tofu` | Add `infisical_boot_token` sensitive variable |
| `modules/vultr/instance/main.tofu` | Add `infisical_boot_token_b64` local, pass to `ct_config` template |
| `modules/vultr/instance/userdata/ghost.bu` | Add `/etc/infisical/access-token` (mode `0600`) |
| `envs/dev/main.tofu` | Pass `instance_replacement_hash` to infisical module, `infisical_boot_token` to vm module |
| `envs/dev/tests/infisical.tofutest.hcl` | Add `null` mock, `infisical_identity_token_auth_token` mock, update TTL assertions, add boot token output assertion |

## Test plan

- [x] PR plan runs cleanly (no errors in `pr-tofu-plan-develop` workflow)
- [x] `infisical_identity_token_auth_token.ghost_dev_boot` appears in plan output as `+ create`
- [x] After merge and deploy: `sudo ls -la /etc/infisical/access-token` shows mode `0600`
- [x] After merge and deploy: `sudo wc -c /etc/infisical/access-token` shows non-zero size
- [x] DNS-only change + apply does NOT replace the instance (hash stable → token stable)
- [x] Instance config change + apply replaces instance with a fresh token