### PR TITLE
GHO-84: Add explicit 24h expiry to Tailscale auth key

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -38,6 +38,10 @@ resource "tailscale_tailnet_key" "this" {
     # Explicitly replace this key whenever the instance would be replaced
     # This guarantees a fresh one-time key when the instance is recreated
     replace_triggered_by = [null_resource.instance_replacement_trigger]
+
+    # Suppress recreation of the existing (already consumed) key when expiry is first added.
+    # The next natural key rotation (via replace_triggered_by) will create with the 24h expiry.
+    ignore_changes = [expiry]
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `expiry = 86400` (24 hours) to `tailscale_tailnet_key.this` in `opentofu/modules/tailscale/main.tofu`
- Reduces the key's validity window from the ~90-day account default to 24 hours
- The key is already `reusable = false` (consumed on first boot); this change only tightens the window between `tofu apply` and instance first boot

## Why

If OpenTofu state were compromised before the instance boots, the raw auth key would be exploitable for up to 90 days under the current defaults. With an explicit 24-hour expiry, that window is bounded to a day — generous enough for CI/CD plus any debugging, but far tighter than the default.

The existing architecture is already correct: `tailscale-auth.service` only runs on first boot (`ConditionPathExists=!/var/lib/tailscale/tailscaled.state`), and `/var/lib/tailscale` persists across reboots. This is a defence-in-depth improvement to the key lifecycle only.

## Test plan

- [ ] `tofu plan` shows no instance replacement (change to `tailscale_tailnet_key` only, not the `null_resource` trigger)
- [ ] CI fmt check and plan pass