### PR TITLE
GHO-85: Prevent boot token TTL expiry from triggering spurious instance rebuild

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -186,7 +186,7 @@ module "vm" {
   mail_smtp_user     = var.mail_smtp_user
   tinybird_api_url   = var.tinybird_api_url
 
-  infisical_boot_token  = module.infisical.ghost_dev_boot_token
+  infisical_boot_token  = terraform_data.boot_token_snapshot.output
   infisical_project_id  = module.infisical.project_id
   infisical_environment = "dev"
 }
@@ -207,4 +207,33 @@ module "infisical" {
   environment               = "dev"
   admin_email               = "noah@noahwhite.net"
   instance_replacement_hash = local.instance_replacement_hash
+}
+
+# ==========================================================================
+# Boot Token Stable Snapshot (GHO-85)
+# ==========================================================================
+# Decouples the Infisical boot token lifecycle (15-min TTL, single-use —
+# Infisical deletes the record after consumption) from user_data.
+#
+# Without this, every plan run after first boot detects the deleted token,
+# recreates it with a new value, and propagates that new value into user_data
+# (ForceNew=true on Vultr instances), triggering an unintended instance rebuild
+# and — critically — rebuilding the instance with the already-consumed Tailscale
+# auth key, breaking Tailscale authentication.
+#
+# This resource captures the token value at instance creation time and holds it
+# stable. It is only replaced when instance_replacement_hash changes (i.e., when
+# the instance is genuinely being replaced), at which point a fresh token is
+# captured for the new instance.
+resource "terraform_data" "boot_token_snapshot" {
+  input            = module.infisical.ghost_dev_boot_token
+  triggers_replace = local.instance_replacement_hash
+
+  lifecycle {
+    # Suppress propagation of token value changes between instance replacements.
+    # After first boot, Infisical deletes the consumed token and OpenTofu recreates
+    # it with a new value. ignore_changes prevents that new value from reaching
+    # user_data and causing an unintended rebuild.
+    ignore_changes = [input]
+  }
 }

--- a/opentofu/modules/vultr/instance/userdata/infisical-secrets-fetch.sh
+++ b/opentofu/modules/vultr/instance/userdata/infisical-secrets-fetch.sh
@@ -7,6 +7,9 @@
 #
 # On reboot the token will be spent/expired — the service logs this and exits 0.
 # The existing .env.secrets file on block storage is used by Ghost as normal.
+#
+# The boot token is delivered via a terraform_data snapshot (GHO-85) which decouples
+# token TTL expiry from user_data, preventing spurious instance rebuilds.
 
 CONFIG_FILE="/etc/ghost-compose/.env.config"
 TOKEN_FILE="/etc/infisical/access-token"


### PR DESCRIPTION
## Summary

- Introduces `terraform_data.boot_token_snapshot` as a stable buffer between the Infisical module output and `module.vm`, decoupling the boot token lifecycle from `user_data`
- Adds a comment to `infisical-secrets-fetch.sh` referencing GHO-85, which changes its file hash and forces `instance_replacement_hash` to change — ensuring the Tailscale auth key is regenerated on this deploy to recover the currently broken instance

## Why

The `infisical_identity_token_auth_token` resource (single-use, 15-min TTL) is deleted by Infisical after the instance consumes it at boot. On the next `tofu plan`, OpenTofu detects the deletion and recreates the token with a new value. That new value propagates through `user_data` (`ForceNew=true`), causing an unintended instance rebuild.

Critically, this rebuild does not change `instance_replacement_hash`, so `tailscale_tailnet_key` is **not** regenerated — the new instance boots with the already-consumed Tailscale auth key and fails to join the tailnet. This is the root cause of the current outage.

## How it works after this fix

| Scenario | Before | After |
|----------|--------|-------|
| `tofu plan` after first boot (no real changes) | Instance rebuild + broken Tailscale auth | No changes |
| `tofu apply` with genuine config changes | Instance rebuild ✓ | Instance rebuild + fresh Tailscale key ✓ |
| This deploy (first time) | N/A | Instance rebuilt, Tailscale key regenerated, instance joins tailnet |

The `terraform_data.boot_token_snapshot` resource:
- Uses `triggers_replace = local.instance_replacement_hash` — only replaced on genuine instance replacements, capturing a fresh token for the new instance
- Uses `ignore_changes = [input]` — suppresses token value changes between deployments (TTL expiry/consumption), keeping `user_data` stable

## Test plan

- [ ] CI plan shows: `terraform_data.boot_token_snapshot` created, `infisical_identity_token_auth_token` recreated, `tailscale_tailnet_key` replaced, instance replaced — all as a single coherent rebuild
- [ ] After deploy: instance is on the tailnet (`tailscale status` shows connected)
- [ ] After deploy: `tailscale-monitor.service` running cleanly
- [ ] Subsequent `tofu plan` with no changes shows zero instance-affecting changes