### PR TITLE
Fix stale tailscale tests; verify GHO-85 no-rebuild on replan

### DIFF
--- a/opentofu/envs/dev/tests/tailscale.tofutest.hcl
+++ b/opentofu/envs/dev/tests/tailscale.tofutest.hcl
@@ -1,4 +1,18 @@
-run "tailscale_auth_key_tests" {
+mock_provider "tailscale" {
+  mock_resource "tailscale_tailnet_key" {
+    defaults = {
+      key = "tskey-auth-mock-1234"
+    }
+  }
+
+  mock_resource "tailscale_acl" {
+    defaults = {}
+  }
+}
+
+mock_provider "null" {}
+
+run "tailscale_auth_key_is_one_time" {
   command = plan
 
   plan_options {
@@ -11,27 +25,31 @@ run "tailscale_auth_key_tests" {
 
   assert {
     condition     = tailscale_tailnet_key.this.preauthorized == true
-    error_message = "Tailscale key should be preauthorized"
+    error_message = "Tailscale key must be preauthorized to allow automatic device registration"
   }
 
   assert {
-    condition     = tailscale_tailnet_key.this.reusable == true
-    error_message = "Tailscale key should be reusable"
+    condition     = tailscale_tailnet_key.this.reusable == false
+    error_message = "Tailscale key must be a one-time key (reusable = false) to prevent reuse after first boot"
   }
 
   assert {
     condition     = tailscale_tailnet_key.this.ephemeral == false
-    error_message = "Tailscale key should not be ephemeral"
+    error_message = "Tailscale key must not be ephemeral — device should persist in tailnet after auth"
   }
 
   assert {
-    condition     = tailscale_tailnet_key.this.description == "Dev Ghost pre-approved auth key"
-    error_message = "Tailscale key should not be ephemeral"
+    condition     = tailscale_tailnet_key.this.description == "ghost-dev"
+    error_message = "Tailscale key description should be 'ghost-dev'"
   }
 
+  assert {
+    condition     = tailscale_tailnet_key.this.expiry == 86400
+    error_message = "Tailscale key must expire in 24 hours (86400s) to limit state exposure window (GHO-84)"
+  }
 }
 
-run "acl-policy-is-correct" {
+run "acl_policy_is_correct" {
   command = plan
 
   plan_options {
@@ -43,72 +61,72 @@ run "acl-policy-is-correct" {
   }
 
   assert {
-    condition     = tailscale_acl.my_tailnet_acl.acl != null
+    condition     = tailscale_acl.soc_tailnet_acl.acl != null
     error_message = "ACL should not be null"
   }
 
   assert {
     condition = (
-      length(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants) == 2 &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].src, "noah@noahwhite.net") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].dst, "tag:ghost-dev") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[0].ip, "22")
+      length(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants) == 2 &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[0].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[0].dst, "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[0].ip, "22")
     )
     error_message = "ACL grants should contain correct source, destination, and port 22 for ghost-dev"
   }
 
   assert {
     condition = (
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[1].src, "noah@noahwhite.net") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[1].dst, "tag:ghost-dev-workstation") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).grants[1].ip, "22")
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[1].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[1].dst, "tag:ghost-dev-workstation") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).grants[1].ip, "22")
     )
     error_message = "ACL grants should contain correct source, destination, and ports for ghost-dev-workstation"
   }
 
   assert {
     condition = (
-      length(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh) == 2 &&
-      jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].action == "accept" &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].src, "noah@noahwhite.net") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].dst, "tag:ghost-dev") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "root") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "autogroup:nonroot") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[0].users, "core")
+      length(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh) == 2 &&
+      jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].action == "check" &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].dst, "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].users, "root") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].users, "autogroup:nonroot") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[0].users, "core")
     )
-    error_message = "SSH rules should allow access from noah@noahwhite.net to tag:ghost-dev with correct users"
+    error_message = "SSH rules should require re-auth (check) from noah@noahwhite.net to tag:ghost-dev with correct users"
   }
 
   assert {
     condition = (
-      jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[1].action == "check" &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[1].src, "noah@noahwhite.net") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[1].dst, "tag:ghost-dev-workstation") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).ssh[1].users, "noah")
+      jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[1].action == "check" &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[1].src, "noah@noahwhite.net") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[1].dst, "tag:ghost-dev-workstation") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).ssh[1].users, "noah")
     )
-    error_message = "SSH rules should check access from noah@noahwhite.net to tag:ghost-dev-workstation with user noah"
+    error_message = "SSH rules should require re-auth (check) from noah@noahwhite.net to tag:ghost-dev-workstation with user noah"
   }
 
   assert {
     condition = (
-      contains(keys(jsondecode(tailscale_acl.my_tailnet_acl.acl).groups), "group:devs") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).groups["group:devs"], "noah@noahwhite.net")
+      contains(keys(jsondecode(tailscale_acl.soc_tailnet_acl.acl).groups), "group:devs") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).groups["group:devs"], "noah@noahwhite.net")
     )
     error_message = "Groups should contain group:devs with noah@noahwhite.net as member"
   }
 
   assert {
     condition = (
-      contains(keys(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners), "tag:ghost-dev") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners["tag:ghost-dev"], "group:devs")
+      contains(keys(jsondecode(tailscale_acl.soc_tailnet_acl.acl).tagOwners), "tag:ghost-dev") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).tagOwners["tag:ghost-dev"], "group:devs")
     )
     error_message = "Tag owners should assign tag:ghost-dev to group:devs"
   }
 
   assert {
     condition = (
-      contains(keys(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners), "tag:ghost-dev-workstation") &&
-      contains(jsondecode(tailscale_acl.my_tailnet_acl.acl).tagOwners["tag:ghost-dev-workstation"], "group:devs")
+      contains(keys(jsondecode(tailscale_acl.soc_tailnet_acl.acl).tagOwners), "tag:ghost-dev-workstation") &&
+      contains(jsondecode(tailscale_acl.soc_tailnet_acl.acl).tagOwners["tag:ghost-dev-workstation"], "group:devs")
     )
     error_message = "Tag owners should assign tag:ghost-dev-workstation to group:devs"
   }

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -35,8 +35,11 @@ resource "tailscale_tailnet_key" "this" {
   tags          = ["tag:ghost-dev"]
 
   lifecycle {
-    # Explicitly replace this key whenever the instance would be replaced
-    # This guarantees a fresh one-time key when the instance is recreated
+    # Explicitly replace this key whenever the instance would be replaced.
+    # This guarantees a fresh one-time key when the instance is recreated.
+    # The instance_replacement_hash only changes on genuine infra changes — the
+    # Infisical boot token is isolated from user_data via terraform_data.boot_token_snapshot
+    # (GHO-85), so token consumption/renewal no longer triggers instance replacement.
     replace_triggered_by = [null_resource.instance_replacement_trigger]
 
     # Suppress recreation of the existing (already consumed) key when expiry is first added.


### PR DESCRIPTION
## Summary

- Fixes broken `tailscale.tofutest.hcl` — tests were stale and would fail if run
- Adds documentation comment to `tailscale/main.tofu` explaining GHO-85's role in keeping `instance_replacement_hash` stable
- The `.tofu` file change triggers the CI `tofu plan` against live state

## What the CI plan verifies (GHO-85 AC)

The `tofu plan` running against the deployed state should show **zero instance-affecting changes**. This confirms that:

1. The Infisical boot token being consumed/renewed no longer propagates to `user_data`
2. `terraform_data.boot_token_snapshot` is holding the token value stable between genuine instance replacements
3. No spurious instance rebuild — the root cause of the post-GHO-84 production incident is fixed

## Tailscale test fixes

`tailscale.tofutest.hcl` had multiple stale failures:

| Issue | Before | After |
|-------|--------|-------|
| Missing `mock_provider` blocks | No mock for `tailscale` or `null` | Added both |
| Resource name | `tailscale_acl.my_tailnet_acl` | `tailscale_acl.soc_tailnet_acl` |
| `reusable` assertion | `== true` | `== false` (one-time key) |
| `description` assertion | `"Dev Ghost pre-approved auth key"` | `"ghost-dev"` |
| SSH `action` assertion | `"accept"` | `"check"` (re-auth required) |
| Missing `expiry` assertion | — | Added `== 86400` (GHO-84) |

## Test plan

- [ ] CI `tofu plan` completes successfully
- [ ] Plan output shows **no resource replacements** for `vultr_instance`, `tailscale_tailnet_key`, or `terraform_data.boot_token_snapshot`
- [ ] Plan output shows `No changes` or only non-instance-affecting changes