### PR TITLE
GHO-87: Add credential-free tofu fmt and tofu test support to infra-shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,18 +330,37 @@ Use `./opentofu/scripts/tofu.sh` instead of `tofu` directly:
 
 ## Running Locally
 
-### Using the ghost-stack-shell container
+### Full infra shell (requires credentials)
+```bash
+./docker/scripts/infra-shell.sh
+```
+Builds the container, retrieves all secrets from Bitwarden, and drops you into an interactive shell with all `TF_VAR_*` variables set. Use this for `tofu plan`, `tofu apply`, etc.
+
+### Format check and tests (no credentials required)
+```bash
+./docker/scripts/infra-shell.sh --no-secrets
+```
+Builds the container and drops you into a lightweight shell with no credential retrieval. Use this for `tofu fmt` and `tofu test`:
+
+```bash
+# Inside the --no-secrets container:
+
+# Check formatting
+./opentofu/scripts/tofu.sh dev fmt
+
+# Run unit tests with mock providers
+./opentofu/scripts/tofu.sh dev test
+```
+
+Both commands work without any credentials. `tofu test` automatically runs `tofu init -backend=false` and sets a dummy `TAILSCALE_API_KEY` if one is not already present.
+
+### Using the ghost-stack-shell container directly
 ```bash
 docker run -it --rm \
   -v "${PWD}:/home/devops/app" \
   -w /home/devops/app \
   ghcr.io/noahwhite/ghost-stack-shell:latest \
   bash
-```
-
-### Format checking
-```bash
-tofu fmt -check -recursive opentofu/
 ```
 
 ## Ghost Instance Access

--- a/docker/scripts/infra-shell.sh
+++ b/docker/scripts/infra-shell.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 #   Workstation interactive (current behavior):
 #     ./docker/scripts/infra-shell.sh
 #
+#   Workstation credential-free (tofu fmt / tofu test only):
+#     ./docker/scripts/infra-shell.sh --no-secrets
+#
 #   CI: retrieve secrets and export to GitHub Actions env:
 #     ./docker/scripts/infra-shell.sh --ci --secrets-only --export-github-env
 #
@@ -30,6 +33,7 @@ set -euo pipefail
 # ----------------------------
 CI_MODE=false
 SECRETS_ONLY=false
+NO_SECRETS=false
 EXPORT_GITHUB_ENV=false
 RUN_CONTAINER=true
 BUILD_CONTAINER=true
@@ -41,6 +45,7 @@ Usage: infra-shell.sh [options]
 Options:
   --ci                 Non-interactive mode. Never prompts. Requires env vars / BWS_ACCESS_TOKEN.
   --secrets-only        Retrieve and export secrets, then exit. Skips IP discovery, SSH key, docker build/run.
+  --no-secrets          Skip all credential retrieval. Launches a lightweight container for tofu fmt / tofu test.
   --export-github-env   Write exported secrets to $GITHUB_ENV (GitHub Actions). Also works if $GITHUB_ENV is set.
   --no-build            Do not run docker build (workstation only).
   --no-run              Do not run docker run (workstation only).
@@ -53,6 +58,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --ci) CI_MODE=true; shift ;;
     --secrets-only) SECRETS_ONLY=true; RUN_CONTAINER=false; BUILD_CONTAINER=false; shift ;;
+    --no-secrets) NO_SECRETS=true; shift ;;
     --export-github-env) EXPORT_GITHUB_ENV=true; shift ;;
     --no-build) BUILD_CONTAINER=false; shift ;;
     --no-run) RUN_CONTAINER=false; shift ;;
@@ -141,7 +147,7 @@ prompt_if_empty() {
 
 # Decide whether to use BWS
 USE_BWS=false
-if check_bws_available; then
+if check_bws_available && [[ "$NO_SECRETS" == "false" ]]; then
   # In CI mode, never prompt; require BWS_ACCESS_TOKEN if you expect to use BWS.
   if [[ -z "${BWS_ACCESS_TOKEN:-}" ]]; then
     if [[ "$CI_MODE" == "true" ]]; then
@@ -169,8 +175,10 @@ else
 fi
 
 # ============================================================================
-# Retrieve secrets
+# Retrieve secrets (skipped in --no-secrets mode)
 # ============================================================================
+
+if [[ "$NO_SECRETS" == "false" ]]; then
 
 if [[ "$USE_BWS" == "true" ]]; then
   # Retrieve into local variables (do not echo values)
@@ -349,6 +357,8 @@ echo "Using SSH public key: $PUBKEY_PATH"
 : "${TF_VAR_infisical_client_secret:?Environment variable not set}"
 : "${TF_VAR_infisical_org_id:?Environment variable not set}"
 
+fi  # end NO_SECRETS check
+
 # Exit early for CI secrets-only mode (no IP discovery, no SSH key, no docker actions)
 if [[ "$SECRETS_ONLY" == "true" ]]; then
   echo "Secrets exported successfully."
@@ -362,34 +372,43 @@ fi
 
 # Run container if enabled
 if [[ "$RUN_CONTAINER" == "true" ]]; then
-  HISTFILE=/dev/null HISTSIZE=0 HISTFILESIZE=0 docker run --rm -it \
-    -e TF_VAR_vultr_api_key \
-    -e TF_VAR_cloudflare_account_id \
-    -e TF_VAR_cloudflare_api_token \
-    -e TF_VAR_ssh_public_key \
-    -e TF_VAR_admin_subnets \
-    -e TF_VAR_admin_ip \
-    -e R2_ACCESS_KEY_ID \
-    -e R2_SECRET_ACCESS_KEY \
-    -e TAILSCALE_API_KEY \
-    -e TAILSCALE_TAILNET \
-    -e TF_VAR_tailscale_tailnet \
-    -e TF_VAR_PD_CLIENT_ID \
-    -e TF_VAR_PD_CLIENT_SECRET \
-    -e TF_VAR_pd_subdomain \
-    -e TF_VAR_pd_user_tok \
-    -e TF_VAR_GC_ACCESS_TOK \
-    -e TF_VAR_SOC_DEV_TERRAFORM_SA_TOK \
-    -e TF_VAR_infisical_client_id \
-    -e TF_VAR_infisical_client_secret \
-    -e TF_VAR_infisical_org_id \
-    -e USER_UID="$(id -u)" \
-    -e USER_GID="$(id -g)" \
-    -e DISPLAY=$DISPLAY \
-    -e XAUTHORITY=$XAUTHORITY \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -v "$(pwd)":/home/devops/app \
-    -v tofu_plugins:/home/devops/.tofu.d \
-    ghost-stack-shell \
-    bash --norc --noprofile -c 'unset HISTFILE; export HISTFILE=/dev/null; export HISTSIZE=0; export HISTFILESIZE=0; exec bash'
+  if [[ "$NO_SECRETS" == "true" ]]; then
+    # Credential-free container for tofu fmt and tofu test
+    docker run --rm -it \
+      -v "$(pwd)":/home/devops/app \
+      -v tofu_plugins:/home/devops/.tofu.d \
+      ghost-stack-shell \
+      bash --norc --noprofile -c 'unset HISTFILE; export HISTFILE=/dev/null; export HISTSIZE=0; export HISTFILESIZE=0; exec bash'
+  else
+    HISTFILE=/dev/null HISTSIZE=0 HISTFILESIZE=0 docker run --rm -it \
+      -e TF_VAR_vultr_api_key \
+      -e TF_VAR_cloudflare_account_id \
+      -e TF_VAR_cloudflare_api_token \
+      -e TF_VAR_ssh_public_key \
+      -e TF_VAR_admin_subnets \
+      -e TF_VAR_admin_ip \
+      -e R2_ACCESS_KEY_ID \
+      -e R2_SECRET_ACCESS_KEY \
+      -e TAILSCALE_API_KEY \
+      -e TAILSCALE_TAILNET \
+      -e TF_VAR_tailscale_tailnet \
+      -e TF_VAR_PD_CLIENT_ID \
+      -e TF_VAR_PD_CLIENT_SECRET \
+      -e TF_VAR_pd_subdomain \
+      -e TF_VAR_pd_user_tok \
+      -e TF_VAR_GC_ACCESS_TOK \
+      -e TF_VAR_SOC_DEV_TERRAFORM_SA_TOK \
+      -e TF_VAR_infisical_client_id \
+      -e TF_VAR_infisical_client_secret \
+      -e TF_VAR_infisical_org_id \
+      -e USER_UID="$(id -u)" \
+      -e USER_GID="$(id -g)" \
+      -e DISPLAY=$DISPLAY \
+      -e XAUTHORITY=$XAUTHORITY \
+      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      -v "$(pwd)":/home/devops/app \
+      -v tofu_plugins:/home/devops/.tofu.d \
+      ghost-stack-shell \
+      bash --norc --noprofile -c 'unset HISTFILE; export HISTFILE=/dev/null; export HISTSIZE=0; export HISTFILESIZE=0; exec bash'
+  fi
 fi

--- a/opentofu/scripts/tofu.sh
+++ b/opentofu/scripts/tofu.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./opentofu/scripts/tofu.sh <env> <init|plan|apply|destroy|taint|state|output> [extra args...]
+# Usage: ./opentofu/scripts/tofu.sh <env> <init|plan|apply|destroy|taint|state|fmt|test|output> [extra args...]
 # Example:
 #   ./opentofu/scripts/tofu.sh dev init
 #   ./opentofu/scripts/tofu.sh dev plan
 #   ./opentofu/scripts/tofu.sh dev apply -auto-approve
+#   ./opentofu/scripts/tofu.sh dev fmt    # Format check — no credentials needed
+#   ./opentofu/scripts/tofu.sh dev test   # Run tests with mock providers — no credentials needed
 
 ENV="${1:-}"; ACTION="${2:-}"; shift 2 || true
 EXTRA_ARGS=("$@")
 if [[ -z "${ENV}" || -z "${ACTION}" ]]; then
-  echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|output> [extra args...]"
+  echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|fmt|test|output> [extra args...]"
   exit 1
 fi
 
@@ -120,29 +122,49 @@ if [ -n "${TF_VAR_cloudflare_api_token:-}" ]; then
   export CLOUDFLARE_API_TOKEN="${TF_VAR_cloudflare_api_token}"
 fi
 
-# --- Export R2 creds for ALL tofu invocations (backend needs them on plan/apply/etc) ---
-: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID required}"
-: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY required}"
-export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
-export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
-# if you use temporary creds, also export AWS_SESSION_TOKEN before calling this script
-export AWS_EC2_METADATA_DISABLED=true
-
 case "${ACTION}" in
   init)
+    # R2 credentials needed for backend access
+    : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID required}"
+    : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY required}"
+    export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+    export AWS_EC2_METADATA_DISABLED=true
     ensure_backend "${EXTRA_ARGS[@]}"
     tofu -chdir="${ENV_DIR}" init -reconfigure -backend-config="${OUT}" "${EXTRA_ARGS[@]}"
     ;;
 
-  plan|apply|destroy|taint|state|import|test|show|refresh|output)
+  plan|apply|destroy|taint|state|import|show|refresh|output)
+    # R2 credentials needed for backend access
+    : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID required}"
+    : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY required}"
+    export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+    # if you use temporary creds, also export AWS_SESSION_TOKEN before calling this script
+    export AWS_EC2_METADATA_DISABLED=true
     # Always ensure backend is generated and initialized (cheap & robust)
     ensure_backend
     # For provider auth (e.g., Vultr), expect env to be exported outside this script.
     tofu -chdir="${ENV_DIR}" "${ACTION}" "${EXTRA_ARGS[@]}"
     ;;
 
+  fmt)
+    # No credentials needed — pure formatting check.
+    tofu fmt -check -recursive "${REPO_ROOT}/opentofu" "${EXTRA_ARGS[@]}"
+    ;;
+
+  test)
+    # Tests use mock providers. No backend or real credentials needed.
+    # Set a dummy TAILSCALE_API_KEY if not already set — the tailscale provider reads this
+    # from the environment during provider initialization even when mock_provider intercepts
+    # all resource operations.
+    export TAILSCALE_API_KEY="${TAILSCALE_API_KEY:-dummy-for-unit-tests}"
+    tofu -chdir="${ENV_DIR}" init -backend=false
+    tofu -chdir="${ENV_DIR}" test "${EXTRA_ARGS[@]}"
+    ;;
+
   *)
-    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|import|test|show|refresh|output> [extra args...]"
+    echo "Usage: $0 <env> <init|plan|apply|destroy|taint|state|import|fmt|test|show|refresh|output> [extra args...]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- Adds `--no-secrets` flag to `infra-shell.sh` that builds and launches the container without any credential retrieval — intended for format checks and unit tests
- Separates `fmt` and `test` into credential-free actions in `tofu.sh` so they can run without R2, Cloudflare, or provider credentials
- `tofu test` automatically runs `tofu init -backend=false` and sets `TAILSCALE_API_KEY=dummy-for-unit-tests` if not already present
- Documents the new workflow in `CLAUDE.md`

### Root cause of the gap

`tofu.sh` had a top-level unconditional R2 credential check (`R2_ACCESS_KEY_ID required`) that ran before the `case` block, causing all actions (including `test`) to require credentials. `infra-shell.sh` required all production credentials just to launch the container, even for credential-free operations.

### Local workflow (after this PR)

```bash
./docker/scripts/infra-shell.sh --no-secrets
# Inside container:
./opentofu/scripts/tofu.sh dev fmt
./opentofu/scripts/tofu.sh dev test
```

## Test plan

- [ ] `./docker/scripts/infra-shell.sh --no-secrets` launches container without prompting for any credentials
- [ ] `./opentofu/scripts/tofu.sh dev fmt` exits 0 (or exits non-zero with a list of files needing formatting — no credential errors)
- [ ] `./opentofu/scripts/tofu.sh dev test` runs `tofu init -backend=false` then `tofu test`, all tests pass with mock providers
- [ ] CI `pr-tofu-fmt-check.yml` passes (the fmt-check and test steps are unchanged and still work)
- [ ] Full `infra-shell.sh` (without `--no-secrets`) behaves exactly as before