### PR TITLE
GHO-92: Replace 1Password reference with Bitwarden in generate-bootstrap-token.sh

### DIFF
--- a/opentofu/bootstrap/scripts/generate-bootstrap-token.sh
+++ b/opentofu/bootstrap/scripts/generate-bootstrap-token.sh
@@ -96,4 +96,4 @@ fi
 echo -n "$NEW_TOKEN" | pbcopy
 
 echo "✅ R2 bootstrap token created and copied to clipboard."
-echo "📋 Paste it into 1Password and delete securely after use."
+echo "📋 Paste it into Bitwarden secret ID bde8e810-8be6-4090-aa1d-b39b002c9eb8 and save."


### PR DESCRIPTION
## Summary

- Replaces outdated 1Password reference in `generate-bootstrap-token.sh` output with correct Bitwarden secret ID (`bde8e810-8be6-4090-aa1d-b39b002c9eb8`)
- No logic changes — single output message line updated

## Test plan

- [x] Script output after token creation references Bitwarden secret ID `bde8e810-8be6-4090-aa1d-b39b002c9eb8`
- [x] No regressions to token creation or clipboard copy logic