### PR TITLE
chore: retrigger deployment to recover from drift

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -97,6 +97,7 @@ locals {
   # directly to develop will NOT work — deploy-dev.yml requires a PR-backed
   # plan artifact.
   # See: docs/runbooks/retrigger-deployment.md
+  # Last drift recovery: 2026-02-28 (block storage attach failure + Vultr provider bug #688)
   # ==========================================================================
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Retrigger PR to recover from drift caused by manual instance deletion (Vultr block storage attach failure).

## Pre-merge checklist

- [ ] Run `state rm` from infra-shell before the plan CI runs:
  ```bash
  ./opentofu/scripts/tofu.sh dev init
  ./opentofu/scripts/tofu.sh dev state rm module.vm.vultr_instance.this
  ```
- [ ] Plan CI shows `1 to add` for the Vultr instance (no other changes)
- [ ] Tailscale device cleaned up if needed (check `systemctl status tailscale-auth.service` from the emergency shell)

## Context

- Vultr provider bug: [#688](https://github.com/vultr/terraform-provider-vultr/issues/688) — plan errors instead of detecting missing instance; `state rm` required before plan can succeed
- See `docs/runbooks/retrigger-deployment.md` for full procedure