### PR TITLE
chore: retrigger deployment after state rm

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -97,7 +97,7 @@ locals {
   # directly to develop will NOT work — deploy-dev.yml requires a PR-backed
   # plan artifact.
   # See: docs/runbooks/retrigger-deployment.md
-  # Last drift recovery: 2026-02-28 (block storage attach failure + Vultr provider bug #688)
+  # Last drift recovery: 2026-02-28b (state rm complete, retriggering plan)
   # ==========================================================================
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Retrigger PR following `state rm` for drift recovery. State has been cleaned up — plan CI should now show `1 to add` for the Vultr instance.

## Checklist

- [ ] Plan CI shows `1 to add` for the Vultr instance (no other unexpected changes)
- [ ] Merge and approve deployment