### PR TITLE
fix: replace bash -c quoting in create-storage-dirs.service (GHO-96)

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost.bu
+++ b/opentofu/modules/vultr/instance/userdata/ghost.bu
@@ -365,23 +365,23 @@ systemd:
         Description=Create Ghost and Caddy storage directories after block device mount
         After=var-mnt-storage.mount
         Requires=var-mnt-storage.mount
-        
+
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/bash -c '\
-        mkdir -p /var/mnt/storage/ghost/content && chmod 0755 /var/mnt/storage/ghost/content && \
-        mkdir -p /var/mnt/storage/ghost/upload-data && chmod 0755 /var/mnt/storage/ghost/upload-data && \
-        mkdir -p /var/mnt/storage/caddy/data && chmod 0755 /var/mnt/storage/caddy/data && \
-        mkdir -p /var/mnt/storage/caddy/config && chmod 0755 /var/mnt/storage/caddy/config && \
-        mkdir -p /var/mnt/storage/caddy/certs && chmod 0755 /var/mnt/storage/caddy/certs && \
-        mkdir -p /var/mnt/storage/alloy && chmod 0750 /var/mnt/storage/alloy && \
-        mkdir -p /var/mnt/storage/mysql/data && chmod 0755 /var/mnt/storage/mysql/data && \
-        mkdir -p /var/mnt/storage/ghost-compose && chmod 0700 /var/mnt/storage/ghost-compose && \
-        mkdir -p /var/mnt/storage/traffic-analytics/data && chmod 0755 /var/mnt/storage/traffic-analytics/data && \
-        mkdir -p /var/mnt/storage/tinybird && chmod 0755 /var/mnt/storage/tinybird && \
-        touch /var/mnt/storage/ghost-compose/.env.generated && chmod 0600 /var/mnt/storage/ghost-compose/.env.generated\'
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/ghost/content
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/ghost/upload-data
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/caddy/data
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/caddy/config
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/caddy/certs
+        ExecStart=/usr/bin/install -d -m 0750 /var/mnt/storage/alloy
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/mysql/data
+        ExecStart=/usr/bin/install -d -m 0700 /var/mnt/storage/ghost-compose
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/traffic-analytics/data
+        ExecStart=/usr/bin/install -d -m 0755 /var/mnt/storage/tinybird
+        ExecStart=/usr/bin/touch /var/mnt/storage/ghost-compose/.env.generated
+        ExecStart=/usr/bin/chmod 0600 /var/mnt/storage/ghost-compose/.env.generated
         RemainAfterExit=true
-        
+
         [Install]
         WantedBy=multi-user.target
 


### PR DESCRIPTION
## Summary

- Fixes `create-storage-dirs.service` which was silently ignored on every boot due to unbalanced quoting in its `ExecStart` directive

## Problem

The `ExecStart` used a multi-line `bash -c '...'` construct that systemd's unit file parser rejected:

```
systemd[1]: create-storage-dirs.service:19: Unbalanced quoting, ignoring: ...
systemd[1]: create-storage-dirs.service: Cannot add dependency job, ignoring: Unit has a bad unit file setting.
```

The service has never run on any instance. This went unnoticed because block storage persists across instance recreations, so directories already existed from initial setup. On a fresh block storage volume the Ghost stack would fail to start.

## Fix

Replaced the single `bash -c '...'` `ExecStart` with individual `ExecStart` lines using `install -d -m MODE`, which creates a directory with the correct permissions atomically. `Type=oneshot` supports multiple `ExecStart` lines executed in sequence.

## Test plan

- [ ] Plan CI shows instance replacement (ghost.bu changed)
- [ ] After deployment: `systemctl status create-storage-dirs.service` shows `active (exited)`
- [ ] After deployment: `journalctl -b | grep create-storage` shows no warnings
- [ ] All storage directories exist with correct permissions: `ls -la /var/mnt/storage/`