### PR TITLE
fix(GHO-69): write processed Caddyfile to /etc/caddy/ so snippet imports resolve

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/caddy-entrypoint.sh
+++ b/opentofu/modules/vultr/instance/userdata/caddy-entrypoint.sh
@@ -17,7 +17,7 @@ HEALTH_CHECK_TOKEN=$(cat /run/secrets/health_check_token)
 # Substitute {$HEALTH_CHECK_TOKEN} using awk.
 # awk -v passes the value as an awk-local variable (not a shell export).
 # BEGIN block escapes & and \ in the token value to prevent awk gsub replacement issues.
-PROCESSED="/run/Caddyfile.processed"
+PROCESSED="/etc/caddy/Caddyfile.processed"
 awk -v tok="$HEALTH_CHECK_TOKEN" '
   BEGIN { gsub(/[&\\]/, "\\\\&", tok) }
   { gsub(/\{\$HEALTH_CHECK_TOKEN\}/, tok); print }


### PR DESCRIPTION
## Summary

- Caddy's `import snippets/Logging` (and other snippets) are resolved relative to the config file location
- `caddy-entrypoint.sh` was writing the awk-processed Caddyfile to `/run/Caddyfile.processed`, causing Caddy to look for snippets at `/run/snippets/` instead of `/etc/caddy/snippets/`
- Fix: write the processed file to `/etc/caddy/Caddyfile.processed` so relative imports resolve correctly

## Test plan

- [ ] Caddy container starts without `File to import not found` error
- [ ] `docker logs ghost-compose-caddy-1` shows Caddy startup without errors
- [ ] Health check responds 200 with valid token
- [ ] `docker exec ghost-compose-caddy-1 env | grep -iE 'health|token'` returns no output (AC still met)