### PR TITLE
fix(GHO-69): bind Ghost server to 0.0.0.0:2368 in config

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-entrypoint.sh
+++ b/opentofu/modules/vultr/instance/userdata/ghost-entrypoint.sh
@@ -14,6 +14,10 @@ TINYBIRD_TOKEN=""
 cat <<EOF > "$CONFIG_PATH"
 {
   "url": "${url:-http://localhost:2368}",
+  "server": {
+    "host": "0.0.0.0",
+    "port": 2368
+  },
   "database": {
     "client": "mysql",
     "connection": {


### PR DESCRIPTION
## Summary

- Adds `"server": {"host": "0.0.0.0", "port": 2368}` to the Ghost `config.production.json` written by `ghost-entrypoint.sh`
- Ensures Ghost binds on all interfaces so Caddy can reach it within the Docker network

## Test plan

- [ ] Deploy and confirm Ghost container starts without crash-looping
- [ ] Confirm `docker logs ghost-compose-ghost-1` shows Ghost listening on port 2368
- [ ] Confirm `https://separationofconcerns.dev` loads (no Cloudflare bad gateway)
- [ ] Verify secrets AC: `docker exec ghost-compose-ghost-1 env` shows no passwords/tokens