### PR TITLE
fix: set contentPath in Ghost config to use block storage volume

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-entrypoint.sh
+++ b/opentofu/modules/vultr/instance/userdata/ghost-entrypoint.sh
@@ -38,6 +38,9 @@ cat <<EOF > "$CONFIG_PATH"
   },
   "tinybird": {
     "adminToken": "${TINYBIRD_TOKEN}"
+  },
+  "paths": {
+    "contentPath": "/var/lib/ghost/content/"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

- Ghost 6.x defaults to writing content (images, logs, etc.) to the versioned installation directory (`versions/6.19.3/content/`) when `paths.contentPath` is not set in `config.production.json`
- Our `ghost-entrypoint.sh` completely overwrites the config but didn't include `paths`, so uploaded images landed in the ephemeral container layer instead of the persistent block storage volume mounted at `/var/lib/ghost/content`
- Adds `"paths": { "contentPath": "/var/lib/ghost/content/" }` to the written config so Ghost writes to the bind-mounted block storage volume (`/var/mnt/storage/ghost/upload-data/`)

## Root Cause

The official Ghost Docker entrypoint writes `paths.contentPath` to the default config. Our custom entrypoint replaces the entire config to inject secrets without exposing them via env vars — but didn't include the `paths` section, causing Ghost to fall back to its versioned installation directory as the content path.

Confirmed diagnosis: images uploaded on the running instance were found at `/var/lib/ghost/versions/6.19.3/content/images/` inside the container, not in `/var/lib/ghost/content/` (the mount point).

## Test plan

- [ ] Deploy to dev instance (triggers instance recreation via `instance_replacement_hash`)
- [ ] Upload an image in Ghost Admin
- [ ] Verify image appears at `/var/mnt/storage/ghost/upload-data/images/` on block storage
- [ ] Verify `docker exec ghost-compose-ghost-1 find /var/lib/ghost/content/images/ -type f` shows the uploaded image
- [ ] Verify image is served correctly at `https://separationofconcerns.dev/content/images/...`