### PR TITLE
feat(GHO-98): Grafana alerting + PagerDuty for backup failures

### DIFF
--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -316,6 +316,47 @@ Note: `/run/` is tmpfs on Flatcar — it is cleared on reboot regardless.
 
 ---
 
+## Alerts
+
+Three Grafana alert rules monitor the backup service. All route to the
+`ghost-stack-dev-01-backup` PagerDuty service.
+
+| Alert | Condition | Fires after |
+|-------|-----------|-------------|
+| Backup Failure | ERROR log line seen in last 10 min | Immediately |
+| Missed Backup Window | No "Backup complete." in 26 hours | 1 hour |
+| Ghost-Compose Down | ghost-compose.service inactive | 15 minutes |
+
+### Silencing Alerts During Planned Maintenance
+
+To silence alerts before planned maintenance (e.g., intentional instance teardown):
+
+1. Log into [Grafana Cloud](https://separationofconcerns0dev.grafana.net)
+2. Navigate to **Alerting** → **Silences** → **Add Silence**
+3. Set matcher: `service = backup`
+4. Set duration to cover the maintenance window
+5. Click **Submit**
+
+Or use the Grafana API:
+```bash
+curl -X POST https://separationofconcerns0dev.grafana.net/api/alertmanager/grafana/api/v2/silences \
+  -H "Authorization: Bearer $GRAFANA_SA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "matchers": [{"name": "service", "value": "backup", "isRegex": false}],
+    "startsAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+    "endsAt": "'"$(date -u -d '+4 hours' +%Y-%m-%dT%H:%M:%SZ)"'",
+    "comment": "Planned maintenance"
+  }'
+```
+
+### Acknowledging a PagerDuty Incident
+
+If paged: acknowledge in PagerDuty, SSH to the instance, and follow the
+Troubleshooting section above. The alerts auto-resolve when conditions clear.
+
+---
+
 ## Related Documentation
 
 - [Infisical Secrets Runbook](./infisical-secrets.md)

--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -163,7 +163,8 @@ module "grafana-cloud" {
   providers = {
     grafana = grafana.cloud
   }
-  SOC_DEV_TERRAFORM_SA_TOK = var.SOC_DEV_TERRAFORM_SA_TOK
+  pagerduty_backup_integration_key = module.pagerduty.backup_integration_key
+  SOC_DEV_TERRAFORM_SA_TOK         = var.SOC_DEV_TERRAFORM_SA_TOK
 }
 
 module "pagerduty" {

--- a/opentofu/envs/dev/tests/grafana-cloud.tofutest.hcl
+++ b/opentofu/envs/dev/tests/grafana-cloud.tofutest.hcl
@@ -38,6 +38,25 @@ mock_provider "grafana" {
     }
   }
 
+  mock_resource "grafana_contact_point" {
+    defaults = {
+      id   = "test-contact-point-id"
+      name = "PagerDuty - Ghost Stack Backup"
+    }
+  }
+
+  mock_resource "grafana_notification_policy" {
+    defaults = {
+      id = "test-notification-policy-id"
+    }
+  }
+
+  mock_resource "grafana_rule_group" {
+    defaults = {
+      id = "test-rule-group-id"
+    }
+  }
+
   mock_data "grafana_data_source" {
     defaults = {
       id   = "test-datasource-id"
@@ -63,7 +82,8 @@ run "grafana_cloud_module_tests" {
   }
 
   variables {
-    SOC_DEV_TERRAFORM_SA_TOK = "test-token"
+    SOC_DEV_TERRAFORM_SA_TOK         = "test-token"
+    pagerduty_backup_integration_key = "test-pd-integration-key"
   }
 
   # Override all data sources to prevent real API calls
@@ -339,5 +359,41 @@ run "grafana_cloud_module_tests" {
   assert {
     condition     = data.grafana_data_source.soc_dev_loki.uid == "grafanacloud-logs"
     error_message = "Loki data source should have correct UID"
+  }
+
+  # Test backup alerting resources (GHO-98)
+  assert {
+    condition     = grafana_contact_point.pagerduty_backup.name == "PagerDuty - Ghost Stack Backup"
+    error_message = "Backup contact point name should be 'PagerDuty - Ghost Stack Backup'"
+  }
+
+  assert {
+    condition     = grafana_rule_group.ghost_stack_backup.name == "Ghost Stack Backup"
+    error_message = "Alert rule group name should be 'Ghost Stack Backup'"
+  }
+
+  assert {
+    condition     = grafana_rule_group.ghost_stack_backup.interval_seconds == 300
+    error_message = "Alert rule group should evaluate every 300 seconds"
+  }
+
+  assert {
+    condition     = length(grafana_rule_group.ghost_stack_backup.rule) == 3
+    error_message = "Alert rule group should have 3 rules"
+  }
+
+  assert {
+    condition     = grafana_folder.ghost_stack_folder.title == "Ghost Stack"
+    error_message = "Ghost Stack folder title should be 'Ghost Stack'"
+  }
+
+  assert {
+    condition     = grafana_dashboard.ghost_stack_backup.config_json != null
+    error_message = "Backup dashboard config should not be null"
+  }
+
+  assert {
+    condition     = jsondecode(grafana_dashboard.ghost_stack_backup.config_json).title == "Ghost Stack Backup"
+    error_message = "Backup dashboard title should be 'Ghost Stack Backup'"
   }
 }

--- a/opentofu/modules/grafana-cloud/main.tofu
+++ b/opentofu/modules/grafana-cloud/main.tofu
@@ -10308,3 +10308,381 @@ data "grafana_dashboard" "soc_dev_grafana_cloud_incident_insights" {
   provider = grafana.soc_dev
   uid      = "009d62c5-179c-4dcf-9bbc-722d5cf8e2c8"
 }
+# =============================================================================
+# Ghost Stack Backup Alerting (GHO-98)
+# =============================================================================
+
+# Folder for backup alert rules and dashboard
+resource "grafana_folder" "ghost_stack_folder" {
+  provider = grafana.soc_dev
+  title    = "Ghost Stack"
+}
+
+resource "grafana_folder_permission" "ghost_stack_folder_permission" {
+  provider   = grafana.soc_dev
+  folder_uid = grafana_folder.ghost_stack_folder.uid
+  org_id     = "0"
+
+  permissions {
+    permission = "Edit"
+    role       = "Editor"
+  }
+  permissions {
+    permission = "View"
+    role       = "Viewer"
+  }
+}
+
+# PagerDuty contact point for backup alerts
+resource "grafana_contact_point" "pagerduty_backup" {
+  provider = grafana.soc_dev
+  name     = "PagerDuty - Ghost Stack Backup"
+
+  pagerduty {
+    integration_key         = var.pagerduty_backup_integration_key
+    severity                = "critical"
+    disable_resolve_message = false
+    class                   = "backup"
+    component               = "ghost-backup.service"
+    group                   = "ghost-stack-dev-01"
+  }
+}
+
+# Root notification policy — routes backup alerts to PagerDuty
+# NOTE: grafana_notification_policy is a singleton that replaces Grafana's entire
+# alert routing tree. Future alert groups must add policy blocks here.
+resource "grafana_notification_policy" "root" {
+  provider      = grafana.soc_dev
+  contact_point = grafana_contact_point.pagerduty_backup.name
+  group_by      = ["alertname", "grafana_folder", "service"]
+
+  policy {
+    matcher {
+      label = "service"
+      match = "="
+      value = "backup"
+    }
+    contact_point   = grafana_contact_point.pagerduty_backup.name
+    group_by        = ["alertname"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "4h"
+  }
+}
+
+# Alert rules — 3 rules covering failure, missed window, compose recovery
+resource "grafana_rule_group" "ghost_stack_backup" {
+  provider         = grafana.soc_dev
+  org_id           = "0"
+  folder_uid       = grafana_folder.ghost_stack_folder.uid
+  name             = "Ghost Stack Backup"
+  interval_seconds = 300
+
+  # Rule 1: Backup failure — ERROR log line seen in last 10 minutes
+  rule {
+    name      = "Backup Failure"
+    condition = "C"
+    for       = "0s"
+
+    no_data_state  = "NoData"
+    exec_err_state = "Error"
+
+    annotations = {
+      summary     = "Ghost backup failed"
+      description = "ghost-backup.service logged an ERROR in the last 10 minutes. Check: journalctl -u ghost-backup -n 50"
+      runbook_url = "https://github.com/noahwhite/ghost-stack/blob/main/docs/runbooks/backup-restore.md"
+    }
+
+    labels = {
+      service  = "backup"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = data.grafana_data_source.soc_dev_loki.uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        datasource = {
+          type = "loki"
+          uid  = data.grafana_data_source.soc_dev_loki.uid
+        }
+        editorMode   = "code"
+        expr         = "{job=~\"integrations/(node_exporter|unix)\", unit=\"ghost-backup.service\"} |= \"ERROR:\""
+        queryType    = "range"
+        refId        = "A"
+        legendFormat = ""
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["A"] }
+          reducer   = { params = [], type = "count" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "A"
+        reducer    = "count"
+        refId      = "B"
+        type       = "reduce"
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [0], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["B"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "B"
+        refId      = "C"
+        type       = "threshold"
+      })
+    }
+  }
+
+  # Rule 2: Missed backup window — no "Backup complete." seen in 26 hours
+  rule {
+    name      = "Missed Backup Window"
+    condition = "C"
+    for       = "1h"
+
+    no_data_state  = "Alerting"
+    exec_err_state = "Alerting"
+
+    annotations = {
+      summary     = "No successful backup in 26 hours"
+      description = "ghost-backup.service has not logged a successful completion in the past 26 hours. Check timer: systemctl list-timers ghost-backup.timer"
+      runbook_url = "https://github.com/noahwhite/ghost-stack/blob/main/docs/runbooks/backup-restore.md"
+    }
+
+    labels = {
+      service  = "backup"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = data.grafana_data_source.soc_dev_loki.uid
+      relative_time_range {
+        from = 93600 # 26 hours
+        to   = 0
+      }
+      model = jsonencode({
+        datasource = {
+          type = "loki"
+          uid  = data.grafana_data_source.soc_dev_loki.uid
+        }
+        editorMode   = "code"
+        expr         = "count_over_time({job=~\"integrations/(node_exporter|unix)\", unit=\"ghost-backup.service\"} |= \"Backup complete.\" [26h])"
+        queryType    = "range"
+        refId        = "A"
+        legendFormat = ""
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["A"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "A"
+        reducer    = "last"
+        refId      = "B"
+        type       = "reduce"
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [1], type = "lt" }
+          operator  = { type = "and" }
+          query     = { params = ["B"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "B"
+        refId      = "C"
+        type       = "threshold"
+      })
+    }
+  }
+
+  # Rule 3: Ghost-compose not running — ghost-compose.service inactive for >15 min
+  # 15-min `for` provides buffer beyond the ~3-5 min backup window
+  rule {
+    name      = "Ghost-Compose Down"
+    condition = "C"
+    for       = "15m"
+
+    no_data_state  = "Alerting"
+    exec_err_state = "Alerting"
+
+    annotations = {
+      summary     = "Ghost-compose is not running"
+      description = "ghost-compose.service has not been active for over 15 minutes. May indicate failure to restart after backup. Check: docker ps && journalctl -u ghost-compose -n 50"
+      runbook_url = "https://github.com/noahwhite/ghost-stack/blob/main/docs/runbooks/backup-restore.md"
+    }
+
+    labels = {
+      service  = "backup"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = data.grafana_data_source.soc_dev_prometheus.uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        datasource = {
+          type = "prometheus"
+          uid  = data.grafana_data_source.soc_dev_prometheus.uid
+        }
+        editorMode   = "code"
+        expr         = "node_systemd_unit_state{job=~\"integrations/node_exporter|unix\", name=\"ghost-compose.service\", state=\"active\"}"
+        legendFormat = "{{instance}}"
+        refId        = "A"
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["A"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "A"
+        reducer    = "last"
+        refId      = "B"
+        type       = "reduce"
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        conditions = [{
+          evaluator = { params = [1], type = "lt" }
+          operator  = { type = "and" }
+          query     = { params = ["B"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+        expression = "B"
+        refId      = "C"
+        type       = "threshold"
+      })
+    }
+  }
+}
+
+# Backup history dashboard — Loki logs panel for ghost-backup.service
+resource "grafana_dashboard" "ghost_stack_backup" {
+  provider = grafana.soc_dev
+  folder   = grafana_folder.ghost_stack_folder.id
+
+  config_json = jsonencode({
+    title       = "Ghost Stack Backup"
+    description = "Backup job history for ghost-backup.service"
+    editable    = true
+    tags        = ["ghost-stack", "backup"]
+    time = {
+      from = "now-7d"
+      to   = "now"
+    }
+    panels = [
+      {
+        id      = 1
+        type    = "logs"
+        title   = "Backup Job Logs"
+        gridPos = { h = 20, w = 24, x = 0, y = 0 }
+        options = {
+          dedupStrategy      = "none"
+          enableLogDetails   = true
+          prettifyLogMessage = false
+          showLabels         = false
+          showTime           = true
+          sortOrder          = "Descending"
+          wrapLogMessage     = false
+        }
+        targets = [
+          {
+            datasource = {
+              type = "loki"
+              uid  = data.grafana_data_source.soc_dev_loki.uid
+            }
+            editorMode   = "code"
+            expr         = "{job=~\"integrations/(node_exporter|unix)\", unit=\"ghost-backup.service\"}"
+            legendFormat = ""
+            refId        = "A"
+          }
+        ]
+        datasource = {
+          type = "loki"
+          uid  = data.grafana_data_source.soc_dev_loki.uid
+        }
+      }
+    ]
+  })
+}

--- a/opentofu/modules/grafana-cloud/variables.tofu
+++ b/opentofu/modules/grafana-cloud/variables.tofu
@@ -3,3 +3,9 @@ variable "SOC_DEV_TERRAFORM_SA_TOK" {
   type        = string
   sensitive   = true
 }
+
+variable "pagerduty_backup_integration_key" {
+  description = "PagerDuty Events API V2 integration key for the Ghost Stack backup service"
+  type        = string
+  sensitive   = true
+}

--- a/opentofu/modules/pagerduty/main.tofu
+++ b/opentofu/modules/pagerduty/main.tofu
@@ -209,6 +209,78 @@ resource "pagerduty_service_dependency" "gsd1ts-soc_blog-sd" {
   }
 }
 
+# =============================================================================
+# Ghost Stack Backup Alerting (GHO-98)
+# =============================================================================
+resource "pagerduty_escalation_policy" "ghost-stack-dev-01-backup-ep" {
+  name        = "ghost-stack-dev-01-backup-ep"
+  description = "Managed by Terraform"
+  num_loops   = 0
+  teams       = []
+
+  rule {
+    escalation_delay_in_minutes = 30
+
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.noahwhite.id
+    }
+  }
+
+  rule {
+    escalation_delay_in_minutes = 30
+
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.noahwhite.id
+    }
+  }
+}
+
+resource "pagerduty_service" "ghost-stack-dev-01-backup" {
+  name                    = "ghost-stack-dev-01-backup"
+  description             = "Ghost stack nightly backup on ghost-stack-dev-01"
+  auto_resolve_timeout    = "null"
+  acknowledgement_timeout = "600"
+  escalation_policy       = pagerduty_escalation_policy.ghost-stack-dev-01-backup-ep.id
+  alert_creation          = "create_alerts_and_incidents"
+
+  auto_pause_notifications_parameters {
+    enabled = true
+    timeout = 300
+  }
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service_integration" "ghost-stack-dev-01-backup_apiv2" {
+  name    = "Events API V2"
+  type    = "events_api_v2_inbound_integration"
+  service = pagerduty_service.ghost-stack-dev-01-backup.id
+}
+
+resource "pagerduty_service_dependency" "backup-flatcar-sd" {
+  dependency {
+    dependent_service {
+      id   = pagerduty_service.ghost-stack-dev-01-backup.id
+      type = "service"
+    }
+    supporting_service {
+      id   = pagerduty_service.flatcar_instance.id
+      type = "service"
+    }
+  }
+}
+
+output "backup_integration_key" {
+  description = "PagerDuty Events API V2 integration key for the backup service"
+  value       = pagerduty_service_integration.ghost-stack-dev-01-backup_apiv2.integration_key
+  sensitive   = true
+}
+
 resource "pagerduty_schedule" "ghost-stack_dev" {
   name        = "ghost-stack dev"
   time_zone   = "America/New_York"


### PR DESCRIPTION
## Summary

- Adds three Grafana alert rules covering backup failure, missed backup window, and ghost-compose not recovering after backup — all routing to a new dedicated PagerDuty service (`ghost-stack-dev-01-backup`)
- Adds a backup history Loki logs dashboard in a new "Ghost Stack" Grafana folder
- All resources managed by OpenTofu; no manual Grafana or PagerDuty UI changes required

## Alert Rules

| Rule | Data Source | Fires after | `no_data_state` |
|------|------------|-------------|-----------------|
| Backup Failure | Loki — ERROR log in last 10 min | Immediately | `NoData` |
| Missed Backup Window | Loki — no "Backup complete." in 26h | 1 hour | `Alerting` |
| Ghost-Compose Down | Prometheus — `ghost-compose.service` inactive | 15 minutes | `Alerting` |

## Files Changed

| File | Change |
|------|--------|
| `opentofu/modules/pagerduty/main.tofu` | Escalation policy, service, Events API V2 integration, service dependency, `backup_integration_key` output |
| `opentofu/modules/grafana-cloud/variables.tofu` | `pagerduty_backup_integration_key` variable |
| `opentofu/modules/grafana-cloud/main.tofu` | Ghost Stack folder, contact point, notification policy, rule group (3 rules), backup dashboard |
| `opentofu/envs/dev/main.tofu` | Wires `pagerduty_backup_integration_key` into grafana-cloud module with corrected `=` alignment |
| `opentofu/envs/dev/tests/grafana-cloud.tofutest.hcl` | 3 mock resources + variable + 7 assertions (all 12 tests pass) |
| `docs/runbooks/backup-restore.md` | New Alerts section with alert table, silence guide, and ack/resolve instructions |

## Test Plan

- [x] `tofu fmt -check -recursive opentofu/` passes (0 formatting errors)
- [x] `tofu test` passes (12/12 tests pass, including 7 new GHO-98 assertions)
- [ ] After deploy: PagerDuty service `ghost-stack-dev-01-backup` visible in PagerDuty
- [ ] After deploy: Grafana Cloud → Alerting → Contact points → "PagerDuty - Ghost Stack Backup" exists
- [ ] After deploy: Grafana Cloud → Alerting → Alert rules → "Ghost Stack" folder → 3 rules
- [ ] After deploy: Grafana Cloud → Dashboards → "Ghost Stack" folder → "Ghost Stack Backup" dashboard
- [ ] End-to-end: Trigger manual backup failure, confirm PagerDuty incident fires and auto-resolves