### PR TITLE
fix(GHO-98): restore non-zero relative_time_range for Loki alert queries

### DIFF
--- a/opentofu/modules/grafana-cloud/main.tofu
+++ b/opentofu/modules/grafana-cloud/main.tofu
@@ -10402,7 +10402,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
       ref_id         = "A"
       datasource_uid = data.grafana_data_source.soc_dev_loki.uid
       relative_time_range {
-        from = 0
+        from = 600
         to   = 0
       }
       model = jsonencode({
@@ -10488,7 +10488,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
       ref_id         = "A"
       datasource_uid = data.grafana_data_source.soc_dev_loki.uid
       relative_time_range {
-        from = 0
+        from = 93600
         to   = 0
       }
       model = jsonencode({


### PR DESCRIPTION
## Summary

- Restores `from = 600` on the Backup Failure step A query
- Restores `from = 93600` on the Missed Backup Window step A query

## Root Cause

Grafana rejects `relative_time_range { from = 0, to = 0 }` on **data source** query steps:

```
failed to update alert rules: invalid alert rule
invalid alert query A: [alerting.alert-rule.invalidRelativeTime]
Invalid alert rule query A: invalid relative time range [From: 0s, To: 0s]
```

`from = 0, to = 0` is valid for **expression** steps (B, C) but not for data source queries (A). Even with `queryType = "instant"`, Grafana requires a non-zero `from` on the data query step. The lookback window in the LogQL expression (`[10m]`, `[26h]`) is independent of this range.

## Test plan

- [ ] `tofu fmt` passes
- [ ] `tofu test` passes (12/12)
- [ ] After deploy: no `invalidRelativeTime` error
- [ ] After deploy: Backup Failure and Missed Backup Window evaluate without `DatasourceError`