### PR TITLE
fix(GHO-98): set no_data_state=OK for Backup Failure and Ghost-Compose Down

### DIFF
--- a/opentofu/modules/grafana-cloud/main.tofu
+++ b/opentofu/modules/grafana-cloud/main.tofu
@@ -10384,7 +10384,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
     condition = "C"
     for       = "0s"
 
-    no_data_state  = "NoData"
+    no_data_state  = "OK"
     exec_err_state = "Error"
 
     annotations = {
@@ -10559,7 +10559,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
     condition = "C"
     for       = "15m"
 
-    no_data_state  = "NoData"
+    no_data_state  = "OK"
     exec_err_state = "Error"
 
     annotations = {


### PR DESCRIPTION
## Summary

- Changes `no_data_state` from `"NoData"` to `"OK"` for the Backup Failure and Ghost-Compose Down alert rules

## Root Cause

Both rules show yellow "No Data" during normal healthy operation:

**Backup Failure:** `count_over_time({unit="ghost-backup.service"} |= "ERROR:" [10m])` — `ghost-backup.service` is a nightly job. For 23+ hours/day there are no log lines in the 10-minute window, so Loki returns an empty result (not 0). With `no_data_state = "NoData"` this renders as yellow. No error logs = healthy = should be green.

**Ghost-Compose Down:** `node_systemd_unit_state{name="ghost-compose.service", state="failed"}` — Prometheus only exports this series when the service is actually in `failed` state. When ghost-compose is running normally, the series doesn't exist → No Data. With `no_data_state = "NoData"` this renders as yellow. No `state=failed` metric = not in failed state = should be green.

## Behaviour after fix

| State | Backup Failure | Ghost-Compose Down |
|-------|---------------|-------------------|
| Normal operation | Green (OK) | Green (OK) |
| Error log seen | Red (Alerting) | — |
| Service in failed state | — | Red (Alerting, after 15m) |

## Test plan

- [ ] `tofu fmt` passes
- [ ] `tofu test` passes (12/12)
- [ ] After deploy: Backup Failure shows green Normal
- [ ] After deploy: Ghost-Compose Down shows green Normal