### PR TITLE
GHO-100: Enable ActivityPub routing via Ghost.org hosted service

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
@@ -32,6 +32,10 @@
         reverse_proxy ghost:2368
     }
 
+    # ActivityPub / Fediverse (GHO-100)
+    # WebFinger, nodeinfo, and activitypub routes proxied to Ghost.org hosted service
+    import snippets/ActivityPub
+
     handle {
         respond "Access Denied" 403
     }
@@ -49,9 +53,6 @@
 
     # Traffic Analytics service (proxies /.ghost/analytics/* to traffic-analytics container)
     import snippets/TrafficAnalytics
-
-    # ActivityPub Service (uncomment when enabled)
-    #import snippets/ActivityPub
 
     # Allow traffic from admin workstation IP
     @allowed_ip {

--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
@@ -22,7 +22,7 @@ services:
       DOMAIN: $${DOMAIN:?DOMAIN environment variable is required}
       ADMIN_DOMAIN: $${ADMIN_DOMAIN:-}
       ADMIN_IP: $${ADMIN_IP:-}
-      # ACTIVITYPUB_TARGET: $${ACTIVITYPUB_TARGET:-https://ap.ghost.org}
+      ACTIVITYPUB_TARGET: $${ACTIVITYPUB_TARGET:-https://ap.ghost.org}
     volumes:
       - /etc/ghost-compose/caddy-entrypoint.sh:/caddy-entrypoint.sh:ro
       - ./caddy:/etc/caddy


### PR DESCRIPTION
## Summary

- Uncomments `ACTIVITYPUB_TARGET` in the Caddy service environment (defaults to `https://ap.ghost.org`)
- Moves `import snippets/ActivityPub` from the **admin domain** block to the **main domain** block — WebFinger (`.well-known/webfinger`), nodeinfo (`.well-known/nodeinfo`), and ActivityPub API routes (`.ghost/activitypub/*`) must be publicly accessible on the main domain, not restricted to the admin subdomain
- The `activitypub` and `activitypub-migrate` container services remain commented out — federation is delegated to Ghost's hosted service (`ap.ghost.org`) for Option A

## Test plan

- [ ] `tofu test` passes (12/12) ✅
- [ ] Deploy completes without errors; instance recreated with new Ignition config
- [ ] `curl "https://separationofconcerns.dev/.well-known/webfinger?resource=acct:index@separationofconcerns.dev"` returns HTTP 200 with valid JSON
- [ ] `curl "https://separationofconcerns.dev/.well-known/nodeinfo"` returns HTTP 200 with valid JSON
- [ ] `curl -H "Accept: application/activity+json" "https://separationofconcerns.dev/.ghost/activitypub/users/index"` returns HTTP 200
- [ ] Existing blog routes unaffected (main site, admin, health check)
- [ ] Hachyderm account can search for and follow `@index@separationofconcerns.dev`

Closes GHO-100