### PR TITLE
chore: retrigger deployment to recover from Vultr block storage attach failure

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -1,5 +1,5 @@
 terraform {
-  # chore: retrigger deployment 2026-03-01
+  # chore: retrigger deployment 2026-03-03
   backend "s3" {}
   required_providers {
     vultr = {


### PR DESCRIPTION
Retrigger PR to reprovision the instance after manually deleting it in Vultr and removing it from OpenTofu state (`module.vm.vultr_instance.this`).

The previous deploy (GHO-100, PR #248) failed due to a Vultr block storage attachment issue. Instance has been removed from state — this plan should show the instance being created fresh.