### PR TITLE
fix(GHO-100): route ActivityPub traffic to ghost:2368 instead of ap.ghost.org

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/env.config.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/env.config.tftpl
@@ -21,8 +21,9 @@ ADMIN_IP=${admin_ip}
 GHOST_VERSION=${ghost_version}
 
 # ActivityPub
-# If you'd prefer to self-host ActivityPub yourself uncomment the line below
-# ACTIVITYPUB_TARGET=activitypub:8080
+# Ghost 6 serves ActivityPub natively — route public federation traffic to Ghost directly.
+# Override to activitypub:8080 when running the self-hosted container (GHO-101).
+ACTIVITYPUB_TARGET=ghost:2368
 
 # Tinybird configuration
 # TINYBIRD_API_URL is the regional endpoint for your Tinybird workspace.


### PR DESCRIPTION
## Summary

Sets `ACTIVITYPUB_TARGET=ghost:2368` in `env.config` so that Caddy proxies WebFinger, nodeinfo, and ActivityPub API routes to Ghost directly rather than to `ap.ghost.org`.

**Root cause:** `ap.ghost.org` is Ghost.org's hosted ActivityPub proxy for Ghost.org-managed blogs. It returns `{"error":"Forbidden","code":"SITE_MISSING"}` for self-hosted instances. Ghost 6 with the Network feature enabled serves ActivityPub natively at `ghost:2368` — no external proxy needed.

`ghost:2368` is reachable from Caddy via the `ghost_network` Docker network; no Vultr firewall changes required.

## Test plan

- [ ] `tofu test` passes (12/12) ✅
- [ ] Deploy completes; instance recreated with new Ignition config
- [ ] `curl "https://separationofconcerns.dev/.well-known/webfinger?resource=acct:index@separationofconcerns.dev"` returns HTTP 200 with valid JSON
- [ ] `curl "https://separationofconcerns.dev/.well-known/nodeinfo"` returns HTTP 200 with valid JSON
- [ ] `curl -H "Accept: application/activity+json" "https://separationofconcerns.dev/.ghost/activitypub/users/index" | jq .type` returns `"Person"` or similar
- [ ] Hachyderm account can follow `@index@separationofconcerns.dev`

Closes GHO-100