### PR TITLE
fix(GHO-100): handle trailing slash redirects from ap.ghost.org

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/ActivityPub
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/snippets/ActivityPub
@@ -4,10 +4,10 @@ handle /.ghost/activitypub/* {
     reverse_proxy {$ACTIVITYPUB_TARGET}
 }
 
-handle /.well-known/webfinger {
+handle /.well-known/webfinger* {
     reverse_proxy {$ACTIVITYPUB_TARGET}
 }
 
-handle /.well-known/nodeinfo {
+handle /.well-known/nodeinfo* {
     reverse_proxy {$ACTIVITYPUB_TARGET}
 }


### PR DESCRIPTION
## Summary

- `ap.ghost.org` returns an HTTP 301 redirect from `/.well-known/webfinger?resource=...` to `/.well-known/webfinger/?resource=...` (trailing slash added by Express.js routing)
- The Caddy `handle /.well-known/webfinger` matcher was exact-path only — the redirected URL `/.well-known/webfinger/` fell through to the catch-all `respond "Access Denied" 403`
- Same issue applies to `/.well-known/nodeinfo`
- Fix: change both to `handle /.well-known/webfinger*` and `handle /.well-known/nodeinfo*` — wildcard catches the bare path, trailing slash variant, and any query strings

**Root cause confirmed via Caddy logs:**
```
ap.ghost.org → 301 → /.well-known/webfinger/ → Caddy catch-all 403
```

## Test plan

- [ ] PR plan CI passes (no infra changes expected — Caddy config is deployed via Ignition/userdata, change lands on next instance recreation or manual Caddy config reload)
- [ ] After deployment: `curl -s "https://separationofconcerns.dev/.well-known/webfinger?resource=acct:index@separationofconcerns.dev"` returns JSON (not 403)
- [ ] `curl -s "https://separationofconcerns.dev/.well-known/nodeinfo"` returns JSON links (not 403)
- [ ] Ghost admin "Network" tab shows ActivityPub active