### PR TITLE
fix(GHO-100): move ActivityPub snippet before @allowed_ip in Caddyfile

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
@@ -22,6 +22,12 @@
         reverse_proxy ghost:2368
     }
 
+    # ActivityPub / Fediverse (GHO-100)
+    # WebFinger, nodeinfo, and activitypub routes proxied to Ghost.org hosted service
+    # Must be imported before @allowed_ip — ActivityPub endpoints are publicly reachable
+    # and must not be swallowed by the admin IP catch-all handler.
+    import snippets/ActivityPub
+
     # Allow traffic from admin workstation IP
     # IP is sourced from .env.config via Docker Compose env_file
     @allowed_ip {
@@ -31,10 +37,6 @@
     handle @allowed_ip {
         reverse_proxy ghost:2368
     }
-
-    # ActivityPub / Fediverse (GHO-100)
-    # WebFinger, nodeinfo, and activitypub routes proxied to Ghost.org hosted service
-    import snippets/ActivityPub
 
     handle {
         respond "Access Denied" 403


### PR DESCRIPTION
## Summary

- The `@allowed_ip` handler was a blanket catch-all — it intercepted **all** requests from the admin workstation IP and proxied them to `ghost:2368`, including `/.well-known/webfinger` and `/.well-known/nodeinfo`
- Because `import snippets/ActivityPub` came **after** `handle @allowed_ip`, ActivityPub routes were never reached for admin IP requests
- `ghost:2368` returns a Ghost 404 page for webfinger — making ActivityPub appear completely broken when tested from the workstation
- Fix: move `import snippets/ActivityPub` **before** `@allowed_ip` so path-based ActivityPub routes match first for all IPs

**Root cause chain:**
```
curl → Cloudflare → Caddy
  → @allowed_ip matches (admin IP) → ghost:2368 → 404 Ghost page  ← BUG

Should be:
curl → Cloudflare → Caddy
  → ActivityPub snippet matches /.well-known/webfinger* → ap.ghost.org → webfinger JSON
```

## Test plan

- [ ] PR plan CI passes
- [ ] After deployment: `curl -sL "https://separationofconcerns.dev/.well-known/webfinger?resource=acct:index@separationofconcerns.dev"` returns JSON (not a Ghost 404)
- [ ] `curl -sL "https://separationofconcerns.dev/.well-known/nodeinfo"` returns JSON links
- [ ] Blog content still loads from admin workstation IP (verifies @allowed_ip still works for non-ActivityPub paths)