### PR TITLE
fix(GHO-100): remove incorrect ACTIVITYPUB_TARGET=ghost:2368 from env.config

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/env.config.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/env.config.tftpl
@@ -21,9 +21,9 @@ ADMIN_IP=${admin_ip}
 GHOST_VERSION=${ghost_version}
 
 # ActivityPub
-# Ghost 6 serves ActivityPub natively — route public federation traffic to Ghost directly.
-# Override to activitypub:8080 when running the self-hosted container (GHO-101).
-ACTIVITYPUB_TARGET=ghost:2368
+# Defaults to https://ap.ghost.org (Ghost.org hosted ActivityPub service) via compose.yml.
+# Uncomment and set to activitypub:8080 for the self-hosted container (GHO-101).
+# ACTIVITYPUB_TARGET=activitypub:8080
 
 # Tinybird configuration
 # TINYBIRD_API_URL is the regional endpoint for your Tinybird workspace.


### PR DESCRIPTION
## Summary

PR #250 was merged with `ACTIVITYPUB_TARGET=ghost:2368` and the incorrect comment that "Ghost 6 serves ActivityPub natively." Ghost does not have a webfinger/ActivityPub endpoint at port 2368 — all federation traffic must route to `ap.ghost.org` (the Ghost.org hosted ActivityPub service).

This explicit value in `.env.config` overrides the correct `https://ap.ghost.org` default in `compose.yml`, causing every webfinger and ActivityPub request to return a Ghost 404 page instead of a federation response.

**Fix:** Remove `ACTIVITYPUB_TARGET=ghost:2368`, restoring the `compose.yml` default of `https://ap.ghost.org`.

## Test plan

- [ ] PR plan CI passes
- [ ] After deployment: `docker exec ghost-compose-caddy-1 env | grep -i activitypub` shows `ACTIVITYPUB_TARGET=https://ap.ghost.org`
- [ ] `curl -sL "https://separationofconcerns.dev/.well-known/webfinger?resource=acct:index@separationofconcerns.dev"` returns JSON (not a Ghost 404)