### PR TITLE
chore: retrigger deployment 2026-03-03 (Infisical boot token drift)

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -98,7 +98,7 @@ locals {
   # directly to develop will NOT work — deploy-dev.yml requires a PR-backed
   # plan artifact.
   # See: docs/runbooks/retrigger-deployment.md
-  # Last drift recovery: 2026-02-28c (retriggering plan)
+  # Last drift recovery: 2026-03-03 (Infisical boot token consumed before deploy)
   # ==========================================================================
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Retrigger deployment after drift check failure on PR #253.

The Infisical single-use boot token was consumed and deleted by the instance between PR plan generation and deploy time. The PR plan showed `-/+ replace` for the token resource; by deploy time it showed `+ create` (already deleted), causing the drift check to fail.

This is benign expected behavior — the outcome is identical (fresh token for the new instance). Opening a fresh PR ensures the plan is generated after the deletion, so PR plan and deploy plan match.

No infrastructure changes — trivial comment update to trigger plan CI.