### PR TITLE
fix(GHO-100): expose /ghost/.well-known/* for ActivityPub JWKS verification

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/caddy/Caddyfile
@@ -35,6 +35,13 @@
         reverse_proxy ghost:2368
     }
 
+    # Ghost Admin site endpoint — ap.ghost.org calls back here during registration to read site
+    # metadata. Ghost redirects /ghost/api/admin/site/ from the main domain to the admin domain,
+    # so this handler catches the initial request before the redirect.
+    handle /ghost/api/admin/site* {
+        reverse_proxy ghost:2368
+    }
+
     # Allow traffic from admin workstation IP
     # IP is sourced from .env.config via Docker Compose env_file
     @allowed_ip {
@@ -62,6 +69,17 @@
 
     # Traffic Analytics service (proxies /.ghost/analytics/* to traffic-analytics container)
     import snippets/TrafficAnalytics
+
+    # Ghost JWKS and Admin site endpoints — must be publicly reachable for ActivityPub registration.
+    # ap.ghost.org follows Ghost's redirect from the main domain to here when fetching JWKS
+    # and site metadata during JWT verification and site registration.
+    handle /ghost/.well-known/* {
+        reverse_proxy ghost:2368
+    }
+
+    handle /ghost/api/admin/site* {
+        reverse_proxy ghost:2368
+    }
 
     # Allow traffic from admin workstation IP
     @allowed_ip {


### PR DESCRIPTION
## Summary

Adds public Caddy handlers required for Ghost to register with `ap.ghost.org` (the Ghost.org-hosted ActivityPub service) and complete ActivityPub/Fediverse initialisation.

## Root Cause Analysis

Ghost registers with ap.ghost.org by calling `{siteUrl}/.ghost/activitypub/v1/site/` with a Bearer JWT. The registration flow makes three outbound callbacks that were all blocked by Caddy's `@allowed_ip` catch-all:

1. **JWKS verification** — ap.ghost.org fetches `{siteUrl}/ghost/.well-known/jwks.json` to verify Ghost's JWT. Ghost redirects this from the main domain to the admin domain.
2. **Site metadata** — ap.ghost.org calls `{siteUrl}/ghost/api/admin/site/` to read site info. Ghost also redirects this to the admin domain.

Because both endpoints redirect to the admin domain, fixes are required in **both** the `{$DOMAIN}` and `{$ADMIN_DOMAIN}` Caddy blocks.

## Changes

### `{$DOMAIN}` block
- `handle /ghost/.well-known/*` — exposes Ghost's JWKS public key endpoint
- `handle /ghost/api/admin/site*` — exposes public site metadata endpoint

### `{$ADMIN_DOMAIN}` block
- `handle /ghost/.well-known/*` — catches redirect from main domain
- `handle /ghost/api/admin/site*` — catches redirect from main domain

Both handlers proxy directly to `ghost:2368`. Neither exposes sensitive data — JWKS is a public key, and the site endpoint returns only title/URL/description/version.

## Verified

All fixes validated on the running instance before committing:
- `curl -sL https://separationofconcerns.dev/ghost/.well-known/jwks.json` → 200 JSON ✓
- Ghost logs: "Checking ActivityPub Webhook state" → "starting fresh" ✓
- 4 webhooks created in DB (`post.published`, `post.deleted`, `post.unpublished`, `post.published.edited`) ✓
- Webfinger returns valid JSON ✓
- Actor profile resolves on Mastodon (`@index@separationofconcerns.dev`) ✓

## Test Plan

- [ ] Deploy and confirm health checks pass
- [ ] Toggle Ghost Network off → on; confirm no "No webhook secret found" error in Ghost logs
- [ ] Confirm 4 webhooks present in DB
- [ ] Confirm `@index@separationofconcerns.dev` resolves on Mastodon