### PR TITLE
GHO-104: add soc-cms directory for Ghost CMS configuration files

### DIFF
--- a/soc-cms/README.md
+++ b/soc-cms/README.md
@@ -1,0 +1,34 @@
+# soc-cms
+
+Ghost CMS configuration files for separationofconcerns.dev.
+
+These files are applied via the Ghost Admin UI or API — they are **not** provisioned
+via Ignition or managed by OpenTofu. This directory is the version-controlled source
+of truth for CMS-level configuration.
+
+## Files
+
+### `redirects.yaml`
+
+URL redirects for the Ghost instance. Maps old Typepad URLs to their Ghost slugs.
+
+**Format:** Ghost's `301:` redirect format — a top-level `301:` key with
+`/old-path: /new-slug/` pairs as children.
+
+**To apply changes:**
+
+1. Update `redirects.yaml` in this directory and merge via PR
+2. Log into [Ghost Admin](https://admin.separationofconcerns.dev/ghost)
+3. Navigate to **Settings** → **Labs**
+4. Under **Redirects**, click **Upload redirects file**
+5. Select the updated `redirects.yaml` from this directory
+
+> **Note:** Uploading replaces the entire redirects configuration — there is no merge.
+> Always ensure this file contains all active redirects before uploading.
+
+**To verify after upload:**
+
+```bash
+curl -sI https://separationofconcerns.dev/soc/2013/10/docker-glassfish4.html | grep -i location
+# Expected: Location: https://separationofconcerns.dev/docker-glassfish4/
+```

--- a/soc-cms/redirects.yaml
+++ b/soc-cms/redirects.yaml
@@ -1,0 +1,4 @@
+301:
+  /soc/2015/10/using-curl-with-docker-machine-on-el-capitan-.html: /using-curl-with-docker-machine-on-el-capitan/
+  /soc/2013/10/docker-glassfish4.html: /docker-glassfish4/
+  /soc/2011/09/programmatically-generating-oracle-schema-stats-two-ways.html: /programmatically-generating-oracle-schema-stats-two-ways/


### PR DESCRIPTION
## Summary

- Introduces `soc-cms/` at the repo root as the version-controlled home for Ghost CMS artifacts applied via Ghost Admin UI or API (not Ignition/OpenTofu)
- Adds `soc-cms/redirects.yaml` with the 3 Typepad → Ghost 301 redirects from the blog migration (GHO-104 / NWSOC-9)
- Adds `soc-cms/README.md` documenting the directory's purpose and the upload/verification process

## Design Notes

Ghost stores `redirects.yaml` at `/var/mnt/storage/ghost/upload-data/data/redirects.yaml` on block storage (mapped from `/var/lib/ghost/content/data/` in the container). This path is included in the nightly R2 backup — no additional backup config or deployment automation needed.

## Test plan

- [x] `soc-cms/redirects.yaml` contains the 3 Typepad redirects in correct Ghost format
- [x] `soc-cms/README.md` documents upload process and verification steps
- [x] After merging typepad-archive PR #5 and uploading `redirects.yaml` to Ghost Admin, verify redirects with `curl -sI https://separationofconcerns.dev/soc/2013/10/docker-glassfish4.html | grep -i location`