### PR TITLE
fix(GHO-101): add command to activitypub and activitypub-migrate services

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
+++ b/opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
@@ -130,6 +130,7 @@ services:
     image: ghcr.io/tryghost/activitypub:1.1.0@sha256:39c212fe23603b182d68e67d555c6b9b04b1e57459dfc0bef26d6e4980eb04d1
     restart: always
     entrypoint: ["/activitypub-entrypoint.sh"]
+    command: ["node", "dist/app.js"]
     expose:
       - "8080"
     volumes:
@@ -205,6 +206,7 @@ services:
   activitypub-migrate:
     image: ghcr.io/tryghost/activitypub-migrations:1.1.0@sha256:b3ab20f55d66eb79090130ff91b57fe93f8a4254b446c2c7fa4507535f503662
     entrypoint: ["/activitypub-entrypoint.sh"]
+    command: ["up"]
     volumes:
       - /etc/ghost-compose/activitypub-entrypoint.sh:/activitypub-entrypoint.sh:ro
     environment:


### PR DESCRIPTION
## Summary

Docker Compose clears the image CMD when `entrypoint` is overridden without also specifying `command`. Both ActivityPub services used `exec "$@"` in the entrypoint to pass through the image CMD — but with no CMD, the entrypoint exited immediately with code 0 and no logs, causing a silent crash loop.

- `activitypub`: image CMD is `node dist/app.js` — added `command: ["node", "dist/app.js"]`
- `activitypub-migrate`: image CMD is `up` — added `command: ["up"]`

**Root cause:** `exec "$@"` with empty `$@` exits the shell immediately (code 0) with no output.

**Symptom:** Container `Restarting (0)`, no logs — identical to the crash loop encountered during initial GHO-101 development.

**Hot-fixed on instance:** manually added `command` to `/etc/ghost-compose/compose.yml`, ran migrations with `docker compose run --rm activitypub-migrate up` (65 migrations applied), restarted Ghost to register the site. ActivityPub is now operational and exchanging Mastodon activities.

## Test plan

- [x] `activitypub` container starts and stays up
- [x] All 65 DB migrations applied successfully
- [x] `GET /.ghost/activitypub/inbox/index` returns 403 (correct — unauthenticated)
- [x] Ghost restarts and registers site with ActivityPub service
- [x] Mastodon follow/accept activity processed in logs
- [ ] Deploy via CI — instance recreated with correct compose.yml