### PR TITLE
fix(GHO-106): switch Renovate to customManagers regex for compose.yml.tftpl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,20 @@
   "baseBranches": ["develop"],
   "branchPrefix": "feature/renovate-",
   "assignees": ["noahwhite"],
-  "docker-compose": {
-    "fileMatch": ["(^|/)compose\\.yml\\.tftpl$"]
-  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)compose\\.yml\\.tftpl$"],
+      "matchStrings": [
+        "image: (?<depName>[^:\\s$]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group Ghost stack Docker image updates into a single PR with digest pinning",
-      "matchManagers": ["docker-compose"],
+      "matchManagers": ["custom.regex"],
       "matchPackageNames": ["caddy", "mysql", "ghost/traffic-analytics", "ghcr.io/tryghost/activitypub", "ghcr.io/tryghost/activitypub-migrations"],
       "groupName": "Ghost stack Docker images",
       "pinDigests": true


### PR DESCRIPTION
## Summary

- Replaces the `docker-compose` manager (which silently fails to detect packages in `.tftpl` files) with a `customManagers` regex that bypasses YAML parsing entirely
- Updates `matchManagers` in `packageRules` from `docker-compose` to `custom.regex`

**Root cause:** Renovate's docker-compose manager uses a YAML parser that chokes on Terraform template syntax (`$${...}`), resulting in "None detected" in the Dependency Dashboard despite a correct `fileMatch` pattern.

**Regex:** `image: (?<depName>[^:\s$]+):(?<currentValue>[^@\s]+)@(?<currentDigest>sha256:[a-f0-9]+)`

Matches all 5 digest-pinned images; skips `ghost:${GHOST_VERSION:-6-alpine}` (no digest, no match).

## Test plan

- [ ] Merge and trigger a Renovate re-scan (check box in Dependency Dashboard issue #232)
- [ ] Verify Dependency Dashboard updates to show 5 detected dependencies
- [ ] Verify `ghost/traffic-analytics` (1.0.12 → 1.0.148) triggers a grouped update PR