### PR TITLE
fix(GHO-106): add Renovate customManagers config to main branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "baseBranches": ["develop"],
+  "branchPrefix": "feature/renovate-",
+  "assignees": ["noahwhite"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)compose\\.yml\\.tftpl$"],
+      "matchStrings": [
+        "image: (?<depName>[^:\\s$]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group Ghost stack Docker image updates into a single PR with digest pinning",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["caddy", "mysql", "ghost/traffic-analytics", "ghcr.io/tryghost/activitypub", "ghcr.io/tryghost/activitypub-migrations"],
+      "groupName": "Ghost stack Docker images",
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Renovate reads its config from the **default branch (`main`)**, not from `baseBranches`
- The customManagers regex fix from GHO-106 was merged to `develop` only — `main` still had the original minimal config with no managers
- This caused every Renovate run to report "None detected" despite the fix being merged

## Expected after merge

- Renovate will detect 5 images in `compose.yml.tftpl`: `caddy`, `mysql`, `ghost/traffic-analytics`, `ghcr.io/tryghost/activitypub`, `ghcr.io/tryghost/activitypub-migrations`
- Renovate will immediately open a PR to update `ghost/traffic-analytics` `1.0.12` → `1.0.148` (the upstream ghost-docker repo merged this same update 2 days ago)

## No deploy impact

`renovate.json` is not part of the deployed infrastructure — no `instance_replacement_hash` update needed.