### PR TITLE
fix(GHO-106): sync Renovate customManagers config to develop

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "baseBranches": ["develop"],
   "branchPrefix": "feature/renovate-",
   "assignees": ["noahwhite"],
+  "ignorePaths": ["docker/**"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- `develop` still had the old `docker-compose` manager config from GHO-88 (PR #229)
- The customManagers regex fix (GHO-106) only landed on `main` via PR #266
- Without this PR, merging `develop` → `main` for a future release would overwrite the fix and revert Renovate back to broken

## No deploy impact

`renovate.json` is not part of the deployed infrastructure — no `instance_replacement_hash` update needed.