### PR TITLE
fix(GHO-106): ignore docker/ in Renovate to prevent spurious PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "baseBranches": ["develop"],
   "branchPrefix": "feature/renovate-",
   "assignees": ["noahwhite"],
+  "ignorePaths": ["docker/**"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- `config:recommended` enables the built-in `docker-compose` manager which scans all `compose.yml` files in the repo
- This generated PR #268 — a digest update for `docker/ghost6/compose.yml`, a non-deployed reference file running `mysql:8.0.42` (older than the deployed `8.0.44`)
- Add `ignorePaths: ["docker/**"]` so Renovate only manages `compose.yml.tftpl` via the `customManagers` regex

## No deploy impact

`renovate.json` is not part of the deployed infrastructure.