### PR TITLE
fix(GHO-108): add query_type = instant to Loki alert rule data blocks

### DIFF
--- a/opentofu/modules/grafana-cloud/main.tofu
+++ b/opentofu/modules/grafana-cloud/main.tofu
@@ -10401,6 +10401,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
     data {
       ref_id         = "A"
       datasource_uid = data.grafana_data_source.soc_dev_loki.uid
+      query_type     = "instant"
       relative_time_range {
         from = 600
         to   = 0
@@ -10487,6 +10488,7 @@ resource "grafana_rule_group" "ghost_stack_backup" {
     data {
       ref_id         = "A"
       datasource_uid = data.grafana_data_source.soc_dev_loki.uid
+      query_type     = "instant"
       relative_time_range {
         from = 93600
         to   = 0


### PR DESCRIPTION
## Summary

- Grafana provider was bumped from `~> 4.21.0` → `~> 4.28.0` in PR #276. Somewhere in that range the provider started surfacing `query_type` as a first-class top-level attribute on `grafana_rule_group` `data` blocks
- Our config only declared `queryType = "instant"` inside the `model = jsonencode({...})` blob — the new provider version reads it back from the Grafana API and stores it in state as a top-level attribute, causing `tofu plan` to show `- query_type = "instant" -> null` for both backup alert rules
- Left unaddressed, the next infrastructure apply would remove `query_type = "instant"` from the live rules and break both backup alerts

## Changes

Add `query_type = "instant"` as an explicit top-level attribute to the Loki `data` blocks (ref_id `"A"`) in both rules in `opentofu/modules/grafana-cloud/main.tofu`:

- `Backup Failure` rule
- `Missed Backup Window` rule

## Expected plan outcome

`tofu plan` should show **no changes** to `grafana_rule_group.ghost_stack_backup` after this is applied.