### PR TITLE
fix(GHO-110): remove workflow files from infra path filter

### DIFF
--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -37,8 +37,6 @@ jobs:
               - 'opentofu/**/*.sh'
               - 'opentofu/**/userdata/**'
               - 'docker/scripts/**'
-              - '.github/workflows/pr-tofu-*.yml'
-              - '.github/workflows/deploy-dev.yml'
 
   tofu-plan:
     needs: changes


### PR DESCRIPTION
## Summary

- `.github/workflows/deploy-dev.yml` and `.github/workflows/pr-tofu-*.yml` are currently in the infra path filter, causing any action version bump in a workflow file to trigger a full `tofu plan` run including the `dev-ci` environment protection gate
- Workflow file changes do not affect OpenTofu plan output — the filter should only cover files that influence infrastructure state
- The `status` job already handles the no-infra-changes case correctly, so removing these entries is sufficient

## No deploy impact

This PR only modifies the path filter in `pr-tofu-plan-develop.yml`. It does not touch any infrastructure files and will itself skip the plan check once merged.