### PR TITLE
feat: add TryGhost compose sync workflow, remove Renovate Docker tracking

### DIFF
--- a/.github/workflows/sync-tryghost-compose.yml
+++ b/.github/workflows/sync-tryghost-compose.yml
@@ -1,0 +1,168 @@
+name: Sync TryGhost Compose Images
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Fetch upstream compose.yml
+        run: |
+          curl -fsSL \
+            https://raw.githubusercontent.com/TryGhost/ghost-docker/main/compose.yml \
+            -o /tmp/upstream-compose.yml
+
+      - name: Extract and compare images
+        id: compare
+        run: |
+          TFTPL="opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl"
+
+          # Extract upstream images
+          UP_CADDY=$(grep -m1 "image: caddy:" /tmp/upstream-compose.yml | sed 's/.*image: //' | tr -d ' \r')
+          UP_MYSQL=$(grep -m1 "image: mysql:" /tmp/upstream-compose.yml | sed 's/.*image: //' | tr -d ' \r')
+          UP_TRAFFIC=$(grep -m1 "image: ghost/traffic-analytics:" /tmp/upstream-compose.yml | sed 's/.*image: //' | tr -d ' \r')
+          UP_AP=$(grep "image: ghcr.io/tryghost/activitypub:" /tmp/upstream-compose.yml | grep -v "migrations" | sed 's/.*image: //' | tr -d ' \r')
+          UP_MIG=$(grep -m1 "image: ghcr.io/tryghost/activitypub-migrations:" /tmp/upstream-compose.yml | sed 's/.*image: //' | tr -d ' \r')
+
+          # Validate all upstream images were found
+          MISSING=0
+          [ -z "$UP_CADDY"   ] && echo "::error::Upstream image not found for prefix: caddy:"                              && MISSING=1
+          [ -z "$UP_MYSQL"   ] && echo "::error::Upstream image not found for prefix: mysql:"                              && MISSING=1
+          [ -z "$UP_TRAFFIC" ] && echo "::error::Upstream image not found for prefix: ghost/traffic-analytics:"            && MISSING=1
+          [ -z "$UP_AP"      ] && echo "::error::Upstream image not found for prefix: ghcr.io/tryghost/activitypub:"       && MISSING=1
+          [ -z "$UP_MIG"     ] && echo "::error::Upstream image not found for prefix: ghcr.io/tryghost/activitypub-migrations:" && MISSING=1
+          [ "$MISSING" -eq 1 ] && exit 1
+
+          # Detect new untracked upstream images (warn only)
+          while IFS= read -r img; do
+            case "$img" in
+              caddy:*|mysql:*|ghost/traffic-analytics:*|ghcr.io/tryghost/activitypub:*|ghcr.io/tryghost/activitypub-migrations:*|ghost:*) ;;
+              *) echo "::warning::Untracked upstream image detected: $img" ;;
+            esac
+          done < <(grep -E "^\s+image: " /tmp/upstream-compose.yml | sed 's/.*image: //' | tr -d ' \r')
+
+          # Extract local images
+          LC_CADDY=$(grep -m1 "image: caddy:" "$TFTPL" | sed 's/.*image: //' | tr -d ' \r')
+          LC_MYSQL=$(grep -m1 "image: mysql:" "$TFTPL" | sed 's/.*image: //' | tr -d ' \r')
+          LC_TRAFFIC=$(grep -m1 "image: ghost/traffic-analytics:" "$TFTPL" | sed 's/.*image: //' | tr -d ' \r')
+          LC_AP=$(grep "image: ghcr.io/tryghost/activitypub:" "$TFTPL" | grep -v "migrations" | sed 's/.*image: //' | tr -d ' \r')
+          LC_MIG=$(grep -m1 "image: ghcr.io/tryghost/activitypub-migrations:" "$TFTPL" | sed 's/.*image: //' | tr -d ' \r')
+
+          # Compare images and build table rows
+          HAS_CHANGES=false
+
+          check_image() {
+            local name="$1" lv="$2" uv="$3"
+            if [ "$lv" != "$uv" ]; then
+              echo "| \`${name}\` | \`${lv}\` | \`${uv}\` | updated |"
+              HAS_CHANGES=true
+            else
+              echo "| \`${name}\` | \`${lv}\` | — | unchanged |"
+            fi
+          }
+
+          ROW_CADDY=$(check_image   "caddy"                                   "$LC_CADDY"   "$UP_CADDY")
+          ROW_MYSQL=$(check_image   "mysql"                                   "$LC_MYSQL"   "$UP_MYSQL")
+          ROW_TRAFFIC=$(check_image "ghost/traffic-analytics"                 "$LC_TRAFFIC" "$UP_TRAFFIC")
+          ROW_AP=$(check_image      "ghcr.io/tryghost/activitypub"            "$LC_AP"      "$UP_AP")
+          ROW_MIG=$(check_image     "ghcr.io/tryghost/activitypub-migrations" "$LC_MIG"     "$UP_MIG")
+
+          # NOTE: check_image runs in a subshell via $(), so we re-derive HAS_CHANGES here
+          HAS_CHANGES=false
+          [ "$LC_CADDY"   != "$UP_CADDY"   ] && HAS_CHANGES=true
+          [ "$LC_MYSQL"   != "$UP_MYSQL"   ] && HAS_CHANGES=true
+          [ "$LC_TRAFFIC" != "$UP_TRAFFIC" ] && HAS_CHANGES=true
+          [ "$LC_AP"      != "$UP_AP"      ] && HAS_CHANGES=true
+          [ "$LC_MIG"     != "$UP_MIG"     ] && HAS_CHANGES=true
+
+          # Write PR body to file
+          {
+            echo "Automated sync from [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker) \`main\` branch."
+            echo ""
+            echo "| Image | Current | Upstream | Status |"
+            echo "|-------|---------|----------|--------|"
+            echo "$ROW_CADDY"
+            echo "$ROW_MYSQL"
+            echo "$ROW_TRAFFIC"
+            echo "$ROW_AP"
+            echo "$ROW_MIG"
+          } > /tmp/pr-body.md
+
+          # Export upstream values and change flag
+          {
+            echo "up_caddy=$UP_CADDY"
+            echo "up_mysql=$UP_MYSQL"
+            echo "up_traffic=$UP_TRAFFIC"
+            echo "up_ap=$UP_AP"
+            echo "up_mig=$UP_MIG"
+            echo "has_changes=$HAS_CHANGES"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply image updates to compose.yml.tftpl
+        if: steps.compare.outputs.has_changes == 'true'
+        run: |
+          TFTPL="opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl"
+
+          # Use | as sed delimiter (safe: image names never contain |)
+          # activitypub: anchor on digit after colon to avoid matching activitypub-migrations
+          sed -i "s|image: caddy:[^[:space:]]*|image: ${{ steps.compare.outputs.up_caddy }}|" "$TFTPL"
+          sed -i "s|image: mysql:[^[:space:]]*|image: ${{ steps.compare.outputs.up_mysql }}|" "$TFTPL"
+          sed -i "s|image: ghost/traffic-analytics:[^[:space:]]*|image: ${{ steps.compare.outputs.up_traffic }}|" "$TFTPL"
+          sed -i "s|image: ghcr.io/tryghost/activitypub:[0-9][^[:space:]]*|image: ${{ steps.compare.outputs.up_ap }}|" "$TFTPL"
+          sed -i "s|image: ghcr.io/tryghost/activitypub-migrations:[^[:space:]]*|image: ${{ steps.compare.outputs.up_mig }}|" "$TFTPL"
+
+      - name: Find or create tracking issue
+        if: steps.compare.outputs.has_changes == 'true'
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="[Sync] Docker images from TryGhost/ghost-docker"
+
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$ISSUE_TITLE" \
+            --json number,title \
+            --jq ".[] | select(.title | startswith(\"$ISSUE_TITLE\")) | .number" \
+            | head -1)
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_NUMBER=$(gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$ISSUE_TITLE" \
+              --body "Tracking issue for automated Docker image syncs from [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker). Closed automatically when sync PRs are merged." \
+              --assignee noahwhite \
+              --json number \
+              --jq '.number')
+            echo "Created tracking issue #$ISSUE_NUMBER"
+          else
+            echo "Reusing existing tracking issue #$ISSUE_NUMBER"
+          fi
+
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update sync PR
+        if: steps.compare.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: feature/sync-tryghost-images
+          base: develop
+          commit-message: "chore: sync Docker images from TryGhost/ghost-docker"
+          title: "chore: sync Docker images from TryGhost/ghost-docker (closes #${{ steps.issue.outputs.issue_number }})"
+          body-path: /tmp/pr-body.md
+          assignees: noahwhite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,38 +512,45 @@ without reprovisioning).
 
 The Ghost Docker stack is based on [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker).
 
-Caddy, MySQL, and `ghost/traffic-analytics` image updates are automated via Renovate — see `docs/runbooks/renovate.md` for setup and operation. Ghost itself (`ghost:6-alpine`) is intentionally unpinned and not tracked by Renovate.
+Docker image updates are automated via the **TryGhost Compose Sync** workflow (`.github/workflows/sync-tryghost-compose.yml`), which runs daily at 06:30 UTC and syncs directly from TryGhost/ghost-docker's `main` branch. Ghost itself (`ghost:6-alpine`) is intentionally unpinned and not tracked. See `docs/runbooks/renovate.md` for Renovate configuration (GitHub Actions and OpenTofu provider updates only).
 
 ### Current Image Versions
 
-Check `opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl` for current versions:
-- Caddy: `caddy:2.10.2-alpine@sha256:...`
-- MySQL: `mysql:8.0.44@sha256:...`
+From `opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl`:
+- `caddy:2.11.2-alpine`
+- `mysql:8.4.8`
+- `ghost/traffic-analytics:1.0.148`
+- `ghcr.io/tryghost/activitypub:1.1.0`
+- `ghcr.io/tryghost/activitypub-migrations:1.1.0`
 - Ghost: `ghost:6-alpine` (unpinned, uses latest 6.x)
 
-### Upstream Sync Workflow
+### Automated Sync (Primary)
 
-1. **Watch for updates**: Star/watch [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker) for Renovate PRs
+The sync workflow runs daily and:
+1. Fetches `compose.yml` from TryGhost/ghost-docker `main`
+2. Compares each tracked image to the local `compose.yml.tftpl`
+3. If differences exist, opens (or updates) a PR to `develop` with the changes
 
-2. **Check for updates**:
+Trigger manually via **Actions → Sync TryGhost Compose Images → Run workflow**.
+
+### Manual Upstream Sync (Fallback)
+
+1. **Check for updates**:
    ```bash
-   # Compare with upstream
    curl -sL https://raw.githubusercontent.com/TryGhost/ghost-docker/main/compose.yml | diff - opentofu/modules/vultr/instance/userdata/ghost-compose/compose.yml.tftpl
    ```
 
-3. **Update templates**:
+2. **Update templates**:
    - Edit `compose.yml.tftpl` with new image tags and SHA256 digests
-   - Update Caddyfile or snippets if upstream changed them
 
-4. **Deploy** via CI/CD:
+3. **Deploy** via CI/CD:
    ```bash
    git checkout -b feature/update-ghost-compose-images
    git add opentofu/modules/vultr/instance/userdata/ghost-compose/
    git commit -m "chore: update Ghost compose image versions"
    git push -u origin feature/update-ghost-compose-images
    ```
-   Open a PR to `develop`. The plan CI will run automatically — review the plan output,
-   then merge and approve the deployment in GitHub Actions.
+   Open a PR to `develop`.
 
 ### Files to Monitor
 

--- a/docs/runbooks/renovate.md
+++ b/docs/runbooks/renovate.md
@@ -1,20 +1,16 @@
 # Renovate Runbook
 
-This runbook covers the initial setup of the Renovate GitHub App for automated Docker image version updates, and how to verify and manage its operation.
+This runbook covers the initial setup of the Renovate GitHub App for automated dependency updates, and how to verify and manage its operation.
 
 ---
 
 ## Overview
 
-Renovate monitors `compose.yml.tftpl` for new versions of the three pinned Docker images and automatically opens a PR to `develop` when updates are available:
+Renovate monitors GitHub Actions workflow files and OpenTofu providers for version updates, and automatically opens PRs to `develop` when updates are available.
 
-| Image | Tracking |
-|-------|----------|
-| `caddy:*-alpine` | Tag + SHA256 digest |
-| `mysql:8.0.*` | Tag + SHA256 digest |
-| `ghost/traffic-analytics:*` | Tag + SHA256 digest |
+**Docker image updates are handled separately** by the TryGhost Compose Sync workflow (`.github/workflows/sync-tryghost-compose.yml`), which syncs directly from [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker) `main`. See [Updating Ghost Docker Images](../../CLAUDE.md#updating-ghost-docker-images) for details.
 
-`ghost:6-alpine` is intentionally excluded — it is unpinned by design.
+`ghost:6-alpine` is intentionally excluded from all automated tracking — it is unpinned by design.
 
 Configuration lives in `renovate.json` at the repository root.
 
@@ -43,34 +39,16 @@ After installation, Renovate will schedule an initial scan. It will either:
 
 Check the [Renovate dashboard](https://app.renovatebot.com/dashboard) for scan status, or watch for a new PR in the repository.
 
-### Step 3: Confirm the `.tftpl` File Is Detected
-
-After the first scan, verify Renovate found the compose file:
-
-1. Navigate to the repository on GitHub
-2. Look for a Renovate dependency dashboard issue (Renovate creates one automatically)
-3. Confirm `compose.yml.tftpl` appears under detected files
-
-If the file is not detected, check the `fileMatch` pattern in `renovate.json`:
-
-```json
-"docker-compose": {
-  "fileMatch": ["(^|/)compose\\.yml\\.tftpl$"]
-}
-```
-
 ---
 
 ## How Updates Work
 
-When a new image version is released upstream:
+When a new GitHub Actions action version or OpenTofu provider version is released:
 
 1. Renovate detects the version bump on its next scheduled scan
-2. Renovate opens a PR to `develop` with branch name `feature/renovate-ghost-stack-docker-images`
-3. The PR updates the image tag and SHA256 digest in `compose.yml.tftpl`
-4. The standard CI/CD pipeline runs (`tofu fmt` check, `tofu plan`)
-5. Review the plan output — image-only changes will show a userdata hash change (triggering instance recreation)
-6. Merge and approve the deployment in GitHub Actions
+2. Renovate opens a PR to `develop` with branch name `feature/renovate-<package>`
+3. The standard CI/CD pipeline runs
+4. Review and merge
 
 ---
 
@@ -86,15 +64,6 @@ When a new image version is released upstream:
 1. Navigate to **github.com/settings/installations** (or the org settings)
 2. Confirm the Renovate app shows `ghost-stack` in its repository list
 
-### Renovate is not detecting `compose.yml.tftpl`
-
-The `.tftpl` extension is non-standard — Renovate requires the custom `fileMatch` regex in `renovate.json`. Confirm it is present and the file path matches:
-
-```bash
-# From repo root
-grep -r "fileMatch" renovate.json
-```
-
 ### PR branch name does not follow `feature/` convention
 
 The `branchPrefix` in `renovate.json` is set to `feature/renovate-`. If PRs are appearing with a different prefix, check that `renovate.json` has not been overridden by a global Renovate config at the organisation level.
@@ -103,5 +72,5 @@ The `branchPrefix` in `renovate.json` is set to `feature/renovate-`. If PRs are 
 
 ## Related Documentation
 
-- [Updating Ghost Docker Images](../../CLAUDE.md#updating-ghost-docker-images) — manual upstream sync workflow
+- [Updating Ghost Docker Images](../../CLAUDE.md#updating-ghost-docker-images) — automated sync from TryGhost/ghost-docker
 - [Renovate documentation](https://docs.renovatebot.com)

--- a/renovate.json
+++ b/renovate.json
@@ -4,24 +4,5 @@
   "baseBranches": ["develop"],
   "branchPrefix": "feature/renovate-",
   "assignees": ["noahwhite"],
-  "ignorePaths": ["docker/**"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)compose\\.yml\\.tftpl$"],
-      "matchStrings": [
-        "image: (?<depName>[^:\\s$]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
-      ],
-      "datasourceTemplate": "docker"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Group Ghost stack Docker image updates into a single PR with digest pinning",
-      "matchManagers": ["custom.regex"],
-      "matchPackageNames": ["caddy", "mysql", "ghost/traffic-analytics", "ghcr.io/tryghost/activitypub", "ghcr.io/tryghost/activitypub-migrations"],
-      "groupName": "Ghost stack Docker images",
-      "pinDigests": true
-    }
-  ]
+  "ignorePaths": ["docker/**"]
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-tryghost-compose.yml` — runs daily at 06:30 UTC and on `workflow_dispatch`; fetches `compose.yml` from TryGhost/ghost-docker `main`, diffs all five tracked images against `compose.yml.tftpl`, and opens/updates a PR to `develop` when changes are found. Warns on any new untracked images detected upstream.
- Removes the custom regex manager and `packageRules` from `renovate.json`; Renovate now covers GitHub Actions and OpenTofu provider updates only.
- Updates `docs/runbooks/renovate.md` and `CLAUDE.md` to reflect the new automation.

Closes GHO-112.

## Test plan

- [ ] Trigger workflow manually via **Actions → Sync TryGhost Compose Images → Run workflow** on `develop`
- [ ] Verify workflow runs to completion with no errors when images are in sync (no PR created)
- [ ] Verify `::warning::` annotation appears for any untracked upstream images
- [ ] Temporarily edit one image in `compose.yml.tftpl` to a stale value, re-trigger, and confirm a PR is opened targeting `develop` with the correct table in the body
- [ ] Confirm a GitHub tracking issue is created (or reused on second run)
- [ ] Confirm the sync PR is assigned to `noahwhite`
- [ ] Merge the sync PR and verify the tracking issue is closed via the `closes #N` reference