### PR TITLE
fix: use URL output from gh issue create instead of unsupported --json flag

### DIFF
--- a/.github/workflows/sync-tryghost-compose.yml
+++ b/.github/workflows/sync-tryghost-compose.yml
@@ -141,13 +141,12 @@ jobs:
             | head -1)
 
           if [ -z "$ISSUE_NUMBER" ]; then
-            ISSUE_NUMBER=$(gh issue create \
+            ISSUE_URL=$(gh issue create \
               --repo "$GITHUB_REPOSITORY" \
               --title "$ISSUE_TITLE" \
               --body "Tracking issue for automated Docker image syncs from [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker). Closed automatically when sync PRs are merged." \
-              --assignee noahwhite \
-              --json number \
-              --jq '.number')
+              --assignee noahwhite)
+            ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
             echo "Created tracking issue #$ISSUE_NUMBER"
           else
             echo "Reusing existing tracking issue #$ISSUE_NUMBER"


### PR DESCRIPTION
`gh issue create` doesn't support `--json`/`--jq` — those flags are only available on read commands. Captures the URL it returns instead and extracts the issue number with `grep -oE '[0-9]+$'`.