### PR TITLE
fix: sign-commits and consistent branch name for TryGhost sync workflow

### DIFF
--- a/.github/workflows/sync-tryghost-compose.yml
+++ b/.github/workflows/sync-tryghost-compose.yml
@@ -141,13 +141,12 @@ jobs:
             | head -1)
 
           if [ -z "$ISSUE_NUMBER" ]; then
-            ISSUE_NUMBER=$(gh issue create \
+            ISSUE_URL=$(gh issue create \
               --repo "$GITHUB_REPOSITORY" \
               --title "$ISSUE_TITLE" \
               --body "Tracking issue for automated Docker image syncs from [TryGhost/ghost-docker](https://github.com/TryGhost/ghost-docker). Closed automatically when sync PRs are merged." \
-              --assignee noahwhite \
-              --json number \
-              --jq '.number')
+              --assignee noahwhite)
+            ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
             echo "Created tracking issue #$ISSUE_NUMBER"
           else
             echo "Reusing existing tracking issue #$ISSUE_NUMBER"
@@ -160,9 +159,10 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: feature/sync-tryghost-images
+          branch: feature/sync-tryghost-compose-images
           base: develop
           commit-message: "chore: sync Docker images from TryGhost/ghost-docker"
           title: "chore: sync Docker images from TryGhost/ghost-docker (closes #${{ steps.issue.outputs.issue_number }})"
           body-path: /tmp/pr-body.md
+          sign-commits: true
           assignees: noahwhite


### PR DESCRIPTION
Two fixes to the TryGhost compose sync workflow:

- Add `sign-commits: true` to `peter-evans/create-pull-request` — the repo enforces verified signatures on all branches, including bot commits
- Rename sync PR branch from `feature/sync-tryghost-images` to `feature/sync-tryghost-compose-images` for consistency