### PR TITLE
fix: skip MySQL sync when upstream version is not newer than 8.4.8

### DIFF
--- a/.github/workflows/sync-tryghost-compose.yml
+++ b/.github/workflows/sync-tryghost-compose.yml
@@ -61,6 +61,16 @@ jobs:
           LC_AP=$(grep "image: ghcr.io/tryghost/activitypub:" "$TFTPL" | grep -v "migrations" | sed 's/.*image: //' | tr -d ' \r')
           LC_MIG=$(grep -m1 "image: ghcr.io/tryghost/activitypub-migrations:" "$TFTPL" | sed 's/.*image: //' | tr -d ' \r')
 
+          # MySQL downgrade guard: only update if upstream version > 8.4.8
+          # (running instance has 8.4.x data; MySQL cannot read data files from a newer major/minor)
+          MYSQL_FLOOR="8.4.8"
+          UP_MYSQL_VER=$(echo "$UP_MYSQL" | sed 's/mysql:\([^@]*\).*/\1/')
+          MYSQL_FLOOR_WINNER=$(printf '%s\n' "$UP_MYSQL_VER" "$MYSQL_FLOOR" | sort -V | tail -1)
+          if [ "$MYSQL_FLOOR_WINNER" != "$UP_MYSQL_VER" ] || [ "$UP_MYSQL_VER" = "$MYSQL_FLOOR" ]; then
+            echo "::notice::MySQL downgrade guard: upstream $UP_MYSQL_VER <= $MYSQL_FLOOR — skipping MySQL update"
+            UP_MYSQL="$LC_MYSQL"
+          fi
+
           # Compare images and build table rows
           HAS_CHANGES=false
 


### PR DESCRIPTION
Adds a downgrade guard to the TryGhost compose sync workflow for MySQL.

The running instance was upgraded to MySQL 8.4.8 by Renovate (PR #273). MySQL cannot read data files written by a newer version, so syncing back to TryGhost's pinned 8.0.x would break the database on next deployment.

The guard skips the MySQL image update if the upstream version is `<= 8.4.8`, emitting a `::notice::` annotation in the workflow log. MySQL will resume syncing automatically once TryGhost/ghost-docker ships a version `> 8.4.8`.