### PR TITLE
feat(GHO-114): add Claude Code review workflow triggered by @claude comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,7 +8,8 @@ jobs:
   review:
     if: |
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '@claude')
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.login == 'noahwhite'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers Claude Code to review a PR when someone comments `@claude` on it.

**Trigger:** `@claude` comment on any PR
**Auth:** `CLAUDE_CODE_OAUTH_TOKEN` secret (1-year token)
**Action:** `anthropics/claude-code-action@v1`

Closes GHO-114.