### PR TITLE
feat(GHO-114): add Claude Code review workflow to main

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,22 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.login == 'noahwhite'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `claude-review.yml` to `main` so the `issue_comment` trigger is active on the default branch.\n\nTriggered only when `noahwhite` comments `@claude` on a PR. Uses `CLAUDE_CODE_OAUTH_TOKEN` secret.