### PR TITLE
fix(GHO-114): add id-token: write permission for OIDC authentication

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
The `claude-code-action` uses OIDC to authenticate, which requires `id-token: write` in the workflow permissions. Without it the action fails immediately with:\n\n```\nCould not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?\n```