### PR TITLE
fix(GHO-114): add checkout step before claude-code-action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
The action was failing with `fatal: not a git repository` because it tries to fetch the PR branch but no repo is checked out. Adds a `actions/checkout@v4` step before the action.