### PR TITLE
fix(GHO-114): upgrade actions/checkout to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
Upgrades `actions/checkout` from v4 to v6 in `claude-review.yml` to resolve the Node.js 20 deprecation warning. Consistent with the version used in other workflows in this repo.