### PR TITLE
fix(GHO-118): stop traffic-analytics during backup/restore

### DIFF
--- a/opentofu/modules/vultr/instance/userdata/ghost-backup.sh
+++ b/opentofu/modules/vultr/instance/userdata/ghost-backup.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 CONFIG_FILE="/etc/ghost-compose/.env.config"
+GENERATED_FILE="/var/mnt/storage/ghost-compose/.env.generated"
 SECRETS_DIR="/var/mnt/storage/ghost-compose/secrets"
 STORAGE_DIR="/var/mnt/storage"
 COMPOSE_FILE="/etc/ghost-compose/compose.yml"
@@ -22,7 +23,7 @@ trap '
   shred -u "${RCLONE_CONFIG}" 2>/dev/null || true
 ' EXIT
 
-set -a; source "${CONFIG_FILE}"; set +a
+set -a; source "${CONFIG_FILE}"; [ -f "${GENERATED_FILE}" ] && source "${GENERATED_FILE}"; set +a
 
 if [ ! -f "${SECRETS_DIR}/ghost_dev_bckup_r2_access_key_id" ] || \
    [ ! -f "${SECRETS_DIR}/ghost_dev_bckup_r2_secret_access_key" ]; then

--- a/opentofu/modules/vultr/instance/userdata/ghost-restore.sh
+++ b/opentofu/modules/vultr/instance/userdata/ghost-restore.sh
@@ -60,6 +60,7 @@ EOF
 }
 
 CONFIG_FILE="/etc/ghost-compose/.env.config"
+GENERATED_FILE="/var/mnt/storage/ghost-compose/.env.generated"
 SECRETS_DIR="/var/mnt/storage/ghost-compose/secrets"
 STORAGE_DIR="/var/mnt/storage"
 COMPOSE_FILE="/etc/ghost-compose/compose.yml"
@@ -112,7 +113,7 @@ done
 # ---------------------------------------------------------------------------
 # Load env config and credentials
 # ---------------------------------------------------------------------------
-set -a; source "${CONFIG_FILE}"; set +a
+set -a; source "${CONFIG_FILE}"; [ -f "${GENERATED_FILE}" ] && source "${GENERATED_FILE}"; set +a
 
 if [ ! -f "${SECRETS_DIR}/ghost_dev_bckup_r2_access_key_id" ] || \
    [ ! -f "${SECRETS_DIR}/ghost_dev_bckup_r2_secret_access_key" ]; then


### PR DESCRIPTION
## Summary

- `ghost-backup.sh` and `ghost-restore.sh` only sourced `.env.config`, missing `COMPOSE_PROFILES=analytics` set in `.env.generated` by `tinybird-provision.service`
- This caused `docker compose down/up` to skip `traffic-analytics`, leaving it running during backups (data consistency risk) and preventing network cleanup (`Resource is still in use` warning)

## Fix

Source `.env.generated` alongside `.env.config` in both scripts, matching what `ghost-compose.service` does via `--env-file`. This brings `COMPOSE_PROFILES` into the shell environment so `docker compose` manages all profiled services including `traffic-analytics`.

## Test plan

- [ ] Trigger backup: `sudo systemctl start ghost-backup.service & journalctl -u ghost-backup -f`
- [ ] Verify `traffic-analytics` appears in `docker compose down` output
- [ ] Verify no `Resource is still in use` warning
- [ ] Verify all containers restart including `traffic-analytics`
- [ ] Verify site loads after backup completes