### PR TITLE
feat(GHO-119): change instance type from vc2-4c-8gb to vhf-2c-4g

### DIFF
--- a/opentofu/envs/dev/dev.auto.tfvars
+++ b/opentofu/envs/dev/dev.auto.tfvars
@@ -2,7 +2,7 @@ firewall_name = "ghost-fw"
 
 instance_name   = "ghost-dev-01"
 instance_region = "ewr"        # pick your region slug
-instance_plan   = "vc2-4c-8gb" # pick a plan slug
+instance_plan   = "vhf-2c-4g"  # pick a plan slug
 
 ssh_key_name = "ghost-dev-admin"
 


### PR DESCRIPTION
Changes `instance_plan` from `vc2-4c-8gb` (4 vCPU, 8 GB, Regular Compute) to `vhf-2c-4g` (2 vCPU, 4 GB, High Frequency Compute).

This will trigger an instance recreation — block storage and data survive.

## Pre-merge checklist
- [ ] Remove old Tailscale device (`ghost-dev-01`) before approving deployment to avoid naming conflicts

## Test plan
- [ ] `tofu plan` shows instance recreation with new plan type
- [ ] Deployment completes successfully
- [ ] Site loads at `separationofconcerns.dev`
- [ ] Health check passes