### PR TITLE
chore: retrigger deployment for GHO-119 instance type change (vhf-2c-4g)

### DIFF
--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -1,5 +1,5 @@
 terraform {
-  # chore: retrigger deployment 2026-03-03
+  # chore: retrigger deployment 2026-03-16
   backend "s3" {}
   required_providers {
     vultr = {


### PR DESCRIPTION
## Summary

Trivial retrigger to generate a plan artifact for the GHO-119 instance type change (`vc2-4c-8gb` → `vhf-2c-4g`) that was merged in PR #325 without triggering CI (fixed by GHO-120 / PR #327).

## Expected Plan

The plan should show instance replacement due to the `instance_plan` change. This will destroy and recreate the Vultr instance.

## ⚠️ Pre-merge checklist

- [x] Remove the existing `ghost-dev-01` device from [Tailscale admin](https://login.tailscale.com/admin/machines) **before approving the deployment** — the new instance will fail to register if the old device name is still present