### PR TITLE
fix(GHO-119): correct plan slug vhf-2c-4g -> vhf-2c-4gb

### DIFF
--- a/opentofu/envs/dev/dev.auto.tfvars
+++ b/opentofu/envs/dev/dev.auto.tfvars
@@ -1,8 +1,8 @@
 firewall_name = "ghost-fw"
 
 instance_name   = "ghost-dev-01"
-instance_region = "ewr"       # pick your region slug
-instance_plan   = "vhf-2c-4g" # pick a plan slug
+instance_region = "ewr"        # pick your region slug
+instance_plan   = "vhf-2c-4gb" # pick a plan slug
 
 ssh_key_name = "ghost-dev-admin"
 


### PR DESCRIPTION
## Summary

Corrects the Vultr plan slug from `vhf-2c-4g` to `vhf-2c-4gb`. Vultr requires the `b` suffix on RAM designations — the invalid slug caused a 400 during instance creation in PR #328's deployment, leaving the site down.

## ⚠️ Site is currently down

The instance was destroyed but failed to recreate. Merge and approve this deployment ASAP.

## Pre-merge checklist

- [x] Tailscale device `ghost-dev-01` removed from admin console (to prevent `ghost-dev-01-1` naming conflict)