### PR TITLE
fix(GHO-120): add *.tfvars to deploy-dev path filter + retrigger deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,6 +31,7 @@ jobs:
           filters: |
             infra:
               - 'opentofu/**/*.tofu'
+              - 'opentofu/**/*.tfvars'
               - 'opentofu/**/*.bu'
               - 'opentofu/**/*.tftpl'
               - 'opentofu/**/*.sh'

--- a/opentofu/envs/dev/main.tofu
+++ b/opentofu/envs/dev/main.tofu
@@ -1,5 +1,5 @@
 terraform {
-  # chore: retrigger deployment 2026-03-16
+  # chore: retrigger deployment 2026-03-16b
   backend "s3" {}
   required_providers {
     vultr = {


### PR DESCRIPTION
## Summary

- Adds `opentofu/**/*.tfvars` to `deploy-dev.yml` path filter (was missing from GHO-120 / PR #327 which only fixed the plan and fmt-check workflows)
- Trivial `.tofu` comment bump to trigger the deploy for the GHO-119 `vhf-2c-4gb` instance type change

## Root Cause

`deploy-dev.yml` had the same missing `*.tfvars` filter as the other two workflows. PRs #328 and #329 both produced plan artifacts but the deploy was skipped because the path filter returned `infra = false` for the `dev.auto.tfvars` change.

## ⚠️ Pre-merge checklist

- [x] Remove `ghost-dev-01` from [Tailscale admin](https://login.tailscale.com/admin/machines) before approving the deployment