### PR TITLE
ci: add concurrency group to plan workflow to cancel superseded runs (GHO-122)

### DIFF
--- a/.github/workflows/pr-tofu-plan-develop.yml
+++ b/.github/workflows/pr-tofu-plan-develop.yml
@@ -6,6 +6,10 @@ on:
       - develop
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: tofu-plan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
## Problem

Each commit to a PR spawns a new `PR OpenTofu Plan` run that enters the `waiting` state pending `dev-ci` environment approval. Without a concurrency group, runs from earlier commits pile up indefinitely — they are never dismissed when the PR merges because the cancel endpoint returns 403 for runs blocked on environment protection.

## Fix

Add a `concurrency` group at the workflow level keyed on PR number:

```yaml
concurrency:
  group: tofu-plan-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

When a new commit pushes to an open PR, GitHub automatically cancels the previous waiting run in the same concurrency group before starting the new one. This prevents future pile-up; existing orphaned runs will time out after 30 days.

Closes GHO-122