### PR TITLE
ci: add one-shot workflow to bulk-reject orphaned waiting runs (GHO-123)

### DIFF
--- a/.github/workflows/cleanup-waiting-runs.yml
+++ b/.github/workflows/cleanup-waiting-runs.yml
@@ -1,0 +1,55 @@
+name: "TEMP: Bulk Reject Orphaned Waiting Runs"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Reject all waiting runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          PAGE=1
+          TOTAL=0
+          FAILED=0
+
+          while true; do
+            IDS=$(gh api "repos/$REPO/actions/runs?status=waiting&per_page=100&page=$PAGE" \
+              --jq '.workflow_runs[].id')
+
+            [ -z "$IDS" ] && break
+
+            while IFS= read -r run_id; do
+              ENV_ID=$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+                --jq '.[0].environment.id // empty' 2>/dev/null)
+
+              if [ -z "$ENV_ID" ]; then
+                echo "::warning::Run $run_id has no pending deployment — skipping"
+                continue
+              fi
+
+              if gh api --method POST "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+                --input - <<EOF > /dev/null 2>&1
+          {"environment_ids":[$ENV_ID],"state":"rejected","comment":"Bulk cleanup of orphaned waiting runs (GHO-123)"}
+          EOF
+                then
+                  echo "Rejected run $run_id (env $ENV_ID)"
+                  TOTAL=$((TOTAL + 1))
+                else
+                  echo "::warning::Failed to reject run $run_id"
+                  FAILED=$((FAILED + 1))
+                fi
+            done <<< "$IDS"
+
+            PAGE=$((PAGE + 1))
+          done
+
+          echo ""
+          echo "Done: $TOTAL rejected, $FAILED failed"
+          [ "$FAILED" -gt 0 ] && exit 1 || exit 0


### PR DESCRIPTION
## Problem

115 `PR OpenTofu Plan` runs are stuck in `waiting` state pending `dev-ci` environment approval from PRs that have already merged. `gh run cancel` returns 403 for these runs. The only way to dismiss them is via `POST /pending_deployments` with `state: rejected`, which requires `actions: write` — a permission the fine-grained PAT doesn't have but the built-in `GITHUB_TOKEN` can be granted.

## Solution

Temporary `workflow_dispatch` workflow (`cleanup-waiting-runs.yml`) that:
1. Pages through all `waiting` runs
2. Fetches the pending deployment environment ID for each
3. Rejects each pending deployment using the built-in `GITHUB_TOKEN` with `actions: write`

## Usage

1. Merge this PR
2. **Actions → TEMP: Bulk Reject Orphaned Waiting Runs → Run workflow**
3. Verify all waiting runs are cleared
4. Delete the workflow file (or open a follow-up PR to remove it)

Closes GHO-123