### PR TITLE
ci: cherry-pick cleanup workflow to main for immediate use (GHO-123)

### DIFF
--- a/.github/workflows/cleanup-waiting-runs.yml
+++ b/.github/workflows/cleanup-waiting-runs.yml
@@ -1,0 +1,55 @@
+name: "TEMP: Bulk Reject Orphaned Waiting Runs"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Reject all waiting runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          PAGE=1
+          TOTAL=0
+          FAILED=0
+
+          while true; do
+            IDS=$(gh api "repos/$REPO/actions/runs?status=waiting&per_page=100&page=$PAGE" \
+              --jq '.workflow_runs[].id')
+
+            [ -z "$IDS" ] && break
+
+            while IFS= read -r run_id; do
+              ENV_ID=$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+                --jq '.[0].environment.id // empty' 2>/dev/null)
+
+              if [ -z "$ENV_ID" ]; then
+                echo "::warning::Run $run_id has no pending deployment — skipping"
+                continue
+              fi
+
+              if gh api --method POST "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+                --input - <<EOF > /dev/null 2>&1
+          {"environment_ids":[$ENV_ID],"state":"rejected","comment":"Bulk cleanup of orphaned waiting runs (GHO-123)"}
+          EOF
+                then
+                  echo "Rejected run $run_id (env $ENV_ID)"
+                  TOTAL=$((TOTAL + 1))
+                else
+                  echo "::warning::Failed to reject run $run_id"
+                  FAILED=$((FAILED + 1))
+                fi
+            done <<< "$IDS"
+
+            PAGE=$((PAGE + 1))
+          done
+
+          echo ""
+          echo "Done: $TOTAL rejected, $FAILED failed"
+          [ "$FAILED" -gt 0 ] && exit 1 || exit 0


### PR DESCRIPTION
`workflow_dispatch` workflows only appear in the Actions UI when on the default branch (`main`). Cherry-picking the cleanup workflow from `develop` so it can be triggered immediately.

**After use:** delete `cleanup-waiting-runs.yml` from `main` (and it will be absent when `develop` is eventually merged to `main` since we'll remove it first).

See #337 for full context.