### PR TITLE
feat(OFF-54): add Tailscale SSH ACL rules for tag:infisical and tag:infisical-ci

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -79,7 +79,20 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "src"    = ["noah@noahwhite.net"],
         "dst"    = ["tag:ghost-dev-workstation"],
         "users"  = ["noah"],
-      }
+      },
+      {
+        "action" = "check",
+        "src"    = ["noah@noahwhite.net"],
+        "dst"    = ["tag:infisical"],
+        "users"  = ["core"],
+      },
+      # CI runner (tag:infisical-ci) can SSH to infisical host without interactive re-auth
+      {
+        "action" = "accept",
+        "src"    = ["tag:infisical-ci"],
+        "dst"    = ["tag:infisical"],
+        "users"  = ["core"],
+      },
     ],
     "groups" = {
       "group:devs" = ["noah@noahwhite.net"],
@@ -87,7 +100,8 @@ resource "tailscale_acl" "soc_tailnet_acl" {
     "tagOwners" = {
       "tag:ghost-dev"             = ["group:devs"],
       "tag:ghost-dev-workstation" = ["group:devs"],
-      "tag:infisical"             = ["group:devs"]
+      "tag:infisical"             = ["group:devs"],
+      "tag:infisical-ci"          = ["group:devs"],
     },
   })
 }


### PR DESCRIPTION
## Summary

- Adds SSH rule: `noah@noahwhite.net` → `tag:infisical` (action: `check`, users: `core`) — operator SSH access to infisical host
- Adds SSH rule: `tag:infisical-ci` → `tag:infisical` (action: `accept`, users: `core`) — CI runner SSH access for `provision-secrets` workflow
- Adds `tag:infisical-ci` to `tagOwners` (owned by `group:devs`)

`tag:infisical-ci` is used by the Tailscale GitHub Action in the `infisical-stack` `provision-secrets` workflow. Using `action: accept` (not `check`) so the ephemeral CI node can SSH non-interactively.

## Test plan

- [ ] Plan CI passes
- [ ] Merge → deploy applies ACL change
- [ ] `provision-secrets` workflow in infisical-stack can SSH to infisical host over Tailscale