### PR TITLE
feat(OFF-54): add grants entry for tag:infisical-ci to tag:infisical

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -64,6 +64,11 @@ resource "tailscale_acl" "soc_tailnet_acl" {
           "udp:21119",
           "udp:43178",
         "tcp:21119"]
+      },
+      {
+        "src" : ["tag:infisical-ci"],
+        "dst" : ["tag:infisical"],
+        "ip" : ["*"]
       }
     ],
     "ssh" = [

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -79,7 +79,20 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "src"    = ["noah@noahwhite.net"],
         "dst"    = ["tag:ghost-dev-workstation"],
         "users"  = ["noah"],
-      }
+      },
+      {
+        "action" = "check",
+        "src"    = ["noah@noahwhite.net"],
+        "dst"    = ["tag:infisical"],
+        "users"  = ["core"],
+      },
+      # CI runner (tag:infisical-ci) can SSH to infisical host without interactive re-auth
+      {
+        "action" = "accept",
+        "src"    = ["tag:infisical-ci"],
+        "dst"    = ["tag:infisical"],
+        "users"  = ["core"],
+      },
     ],
     "groups" = {
       "group:devs" = ["noah@noahwhite.net"],
@@ -87,7 +100,8 @@ resource "tailscale_acl" "soc_tailnet_acl" {
     "tagOwners" = {
       "tag:ghost-dev"             = ["group:devs"],
       "tag:ghost-dev-workstation" = ["group:devs"],
-      "tag:infisical"             = ["group:devs"]
+      "tag:infisical"             = ["group:devs"],
+      "tag:infisical-ci"          = ["group:devs"],
     },
   })
 }


### PR DESCRIPTION
  ## Summary

  Adds a network-level ACL grant allowing `tag:infisical-ci` → `tag:infisical` on all ports.

  The existing `ssh` block entry was insufficient — without a corresponding `grants` entry, Tailscale does not establish
   a peer route between the CI runner and the infisical host, causing MagicDNS resolution and ping to fail entirely.

  Verified manually: adding this rule in the Tailscale admin console fixed connectivity from the CI runner to
  `infisical.$TAILNET_NAME`.

  ## Test plan

  - [x] PR plan CI passes
  - [ ] On merge to develop + deploy: `provision-secrets` workflow ping step succeeds
  - [ ] SCP and SSH to infisical host complete successfully