### PR TITLE
feat(OFF-52): add officina-ci and officina-instance Tailscale tags

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -69,6 +69,16 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "src" : ["tag:infisical-ci"],
         "dst" : ["tag:infisical"],
         "ip" : ["*"]
+      },
+      {
+        "src" : ["tag:officina-ci"],
+        "dst" : ["tag:infisical"],
+        "ip" : ["443"]
+      },
+      {
+        "src" : ["tag:officina-instance"],
+        "dst" : ["tag:infisical"],
+        "ip" : ["443"]
       }
     ],
     "ssh" = [
@@ -107,6 +117,8 @@ resource "tailscale_acl" "soc_tailnet_acl" {
       "tag:ghost-dev-workstation" = ["group:devs"],
       "tag:infisical"             = ["group:devs"],
       "tag:infisical-ci"          = ["group:devs"],
+      "tag:officina-ci"           = ["group:devs"],
+      "tag:officina-instance"     = ["group:devs"],
     },
   })
 }

--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -71,6 +71,11 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "ip" : ["*"]
       },
       {
+        "src" : ["noah@noahwhite.net"],
+        "dst" : ["tag:officina-instance"],
+        "ip" : ["22"]
+      },
+      {
         "src" : ["tag:officina-ci"],
         "dst" : ["tag:infisical"],
         "ip" : ["443"]
@@ -106,6 +111,12 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "action" = "accept",
         "src"    = ["tag:infisical-ci"],
         "dst"    = ["tag:infisical"],
+        "users"  = ["core"],
+      },
+      {
+        "action" = "check",
+        "src"    = ["noah@noahwhite.net"],
+        "dst"    = ["tag:officina-instance"],
         "users"  = ["core"],
       },
     ],


### PR DESCRIPTION
 ## Summary

  - Adds `tag:officina-ci` and `tag:officina-instance` to `tagOwners` so officina CI runners and Ghost instances can
  register on the tailnet
  - Grants both new tags access to `tag:infisical` on port 443 so they can reach the self-hosted Infisical instance via
  Tailscale MagicDNS

  ## Context

  Part of OFF-52 (migrate Officina platform to self-hosted Infisical). Officina CI runners need to run Terragrunt units
  that provision Infisical resources, and Ghost instances need to fetch secrets at boot — both require Tailscale
  connectivity to the Infisical host on port 443.

  `tag:infisical-ci` retains its existing unrestricted grant (`"ip": ["*"]`) for SSH access. The new officina tags are
  scoped to port 443 only (HTTPS/Infisical API).

  ## Test plan

  - [x] `tofu fmt -check -recursive opentofu/` passes
  - [x] `tofu test` passes (14/14)
  - [ ] Plan CI shows only `tailscale_acl` update (no other resource changes)
  - [ ] After merge + deploy: verify `tag:officina-ci` device can reach `infisical.<tailnet>.ts.net:443`