### PR TITLE
feat: allow officina-ci to SSH to officina-instance hosts

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -84,6 +84,11 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "src" : ["tag:officina-instance"],
         "dst" : ["tag:infisical"],
         "ip" : ["443"]
+      },
+      {
+        "src" : ["tag:officina-ci"],
+        "dst" : ["tag:officina-instance"],
+        "ip" : ["22"]
       }
     ],
     "ssh" = [
@@ -118,6 +123,12 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "src"    = ["noah@noahwhite.net"],
         "dst"    = ["tag:officina-instance"],
         "users"  = ["core"],
+      },
+      {
+        "action" = "accept",
+        "src"    = ["tag:officina-ci"],
+        "dst"    = ["tag:officina-instance"],
+        "users"  = ["root"],
       },
     ],
     "groups" = {


### PR DESCRIPTION
## Summary
- Add Tailscale ACL grant: `tag:officina-ci` → `tag:officina-instance` on port 22
- Add Tailscale SSH rule: `tag:officina-ci` → `tag:officina-instance` as `root` (action: accept)

Required for the officina `provision-host-secrets` workflow to deposit tokens and trigger the reconciler on host instances via `tailscale ssh`.

## Test plan
- [x] `tofu plan` shows ACL update
- [ ] After apply, retrigger officina manual workflow — verify `tailscale ssh` connects to ghost-shared-01