### PR TITLE
fix(OFF-64): use core user for officina-ci SSH

### DIFF
--- a/opentofu/modules/tailscale/main.tofu
+++ b/opentofu/modules/tailscale/main.tofu
@@ -128,7 +128,7 @@ resource "tailscale_acl" "soc_tailnet_acl" {
         "action" = "accept",
         "src"    = ["tag:officina-ci"],
         "dst"    = ["tag:officina-instance"],
-        "users"  = ["root"],
+        "users"  = ["core"],
       },
     ],
     "groups" = {


### PR DESCRIPTION
## Summary

- Changes Tailscale SSH ACL rule for `tag:officina-ci` → `tag:officina-instance` from `root` to `core`
- CI workflows will use `core@` with `sudo` for privileged operations instead of direct root access
- Companion to officina-pub/officina#180 which updates the workflow commands

## Test plan

- [ ] ACL applied via deploy
- [ ] Manual provision-host-secrets workflow succeeds with core + sudo