### PR TITLE
docs: correct README and linked docs to match repo reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,168 @@
-> This repository contains the infrastructure-as-code implementation for [**Ghost in the Stack**](https://www.noahwhite.net/soc/ghost-in-the-stack), a blog series exploring real-world DevOps practices from first principles. It documents the full lifecycle of self-hosting a Ghost blog — beginning with a lightweight MVP on Vultr and evolving into a resilient, cloud-native platform.
+# Ghost Stack
 
+Infrastructure-as-code for a self-hosted [Ghost](https://ghost.org/) blog running on
+immutable [Flatcar Container Linux](https://www.flatcar.org/), provisioned with
+[OpenTofu](https://opentofu.org/) and deployed through a GitHub Actions pipeline.
 
-# Ghost Stack (Part 1)
+This repository is the companion codebase to **[Ghost in the Stack](https://www.noahwhite.net/soc/ghost-in-the-stack)**,
+a blog series that builds the platform from first principles. It began as a lightweight
+MVP and has since grown into the full, cloud-native stack described below — automated
+deployments, secrets automation, observability, backups, and ActivityPub federation.
 
-This repository represents the initial phase of a modular, infrastructure-as-code deployment for a self-hosted Ghost blog. It targets a single environment (dev) using Vultr and Cloudflare, and is bootstrapped with OpenTofu.
-
-## Project Overview
-
-- IaC powered by [OpenTofu](https://opentofu.org/)
-- Target environment: `dev`
-- Infrastructure hosted on:
-  - Vultr (Ghost App Server)
-  - Cloudflare (DNS, R2 for state storage)
-- Manual secret management using 1Password GUI
-- Optional containerized tooling for a clean host experience
+> **Scope:** a single-tenant, single-environment (`dev`) deployment. The multi-tenant SaaS
+> evolution lives in a separate project; this repo is the single-tenant foundation.
 
 ---
 
-## Getting Started
+## Architecture at a glance
 
-### Prerequisites
+| Layer | Technology |
+|-------|-----------|
+| Provisioning | OpenTofu (`.tofu` files), modular per-provider |
+| Host OS | Flatcar Container Linux (immutable), configured via Butane → Ignition |
+| Runtime | Docker Compose on the host — Ghost, MySQL, Caddy, ActivityPub, Traffic Analytics |
+| Reverse proxy / TLS | Caddy (automatic HTTPS, security headers, health-check gating) |
+| DNS / CDN / state | Cloudflare (DNS, edge, R2 bucket for remote OpenTofu state) |
+| Cloud host | Vultr (instance, firewall, block storage) |
+| Infra secrets | Bitwarden Secrets Manager (`bws`), injected at runtime — never on disk |
+| App secrets | Infisical, fetched at boot via single-use token, written to block storage |
+| Remote access | Tailscale (SSH is Tailscale-only; no public SSH) |
+| Observability | Grafana Cloud (metrics/logs) + PagerDuty (alerting) |
+| Backups | Scheduled backups to R2 with tiered retention |
+| CI/CD | GitHub Actions — fmt-check, plan-on-PR, gated deploy-on-merge |
 
-- A domain name purchased via a registrar (e.g., Porkbun, Namecheap)
-- A Cloudflare account (scoped to the dev environment)
-- A Vultr account (scoped to the dev environment)
-- [1Password](https://1password.com/) or other similar tool, for secure local secret management
-- Docker (for isolated tooling)
+Persistent state (MySQL data, Ghost content, secrets) lives on Vultr block storage and
+survives host rebuilds; everything else is delivered immutably via Ignition on each deploy.
 
 ---
 
-## Directory Structure
+## Repository structure
 
 ```
 ghost-stack/
+├── CLAUDE.md                     # Full engineering context and operational runbook
 ├── README.md
+├── LICENSE
 ├── docker/
-│   ├── Dockerfile
+│   ├── Dockerfile                # ghost-stack-shell image (OpenTofu 1.11.1 + tooling)
+│   ├── ghost6/compose.yml        # Reference Ghost 6 compose definition
 │   └── scripts/
-│       └── infra-shell.sh
-└── opentofu/
-    ├── envs/
-    │   └── dev/
-    │       ├── backend.tf
-    │       ├── dev.tfvars.example
-    │       ├── main.tf
-    │       ├── prod.tfvars
-    │       └── variables.tf
-    ├── modules/
-    │   ├── cloudflare/
-    │   │   └── dns/
-    │   │       ├── dns.tf
-    │   │       ├── outputs.tf
-    │   │       └── variables.tf
-    │   └── vultr/
-    │       └── vm/
-    │           ├── cloud-init.yml.tpl
-    │           ├── outputs.tf
-    │           ├── variables.tf
-    │           └── vultr-instance.tf
-    ├── scripts/
-    │   ├── apply_dev.sh
-    │   ├── init-dev.sh
-    │   └── plan_dev.sh
-    └── bootstrap/
-				├── README.md
-				├── main.tf
-				├── outputs.tf
-				├── variables.tf
-				├── envs/
-				│   └── dev/
-				│       └── dev.tfvars
-				├── modules/
-				│   ├── cloudflare_zone/
-				│   │   ├── main.tf
-				|		|		├── outputs.tf
-				│   │   └── variables.tf
-				│   └── r2/
-				│       ├── README.md
-				│       ├── main.tf
-				│       └── variables.tf
-				├── scripts/
-				│   ├── bootstrap-dev.sh
-				│   ├── generate-bootstrap-token.sh
-				│   ├── list-permission-groups.sh
-				│   └── set-cloudflare-env.sh
+│       ├── infra-shell.sh        # Interactive shell with secrets injected from Bitwarden
+│       └── bootstrap-infra-shell.sh
+├── opentofu/
+│   ├── envs/dev/                 # Dev environment root module (main.tofu, *.auto.tfvars, tests/)
+│   ├── modules/
+│   │   ├── vultr/                # instance, firewall, block_storage
+│   │   ├── cloudflare/dns_records/
+│   │   ├── tailscale/
+│   │   ├── grafana-cloud/
+│   │   ├── infisical/
+│   │   └── pagerduty/
+│   ├── bootstrap/                # One-time R2 state bucket + Cloudflare zone provisioning
+│   └── scripts/
+│       ├── tofu.sh               # Wrapper: ./tofu.sh <env> <plan|apply|fmt|test>
+│       └── build-ignition.sh     # Transpile Butane (.bu) → Ignition JSON
+├── docs/                         # Runbooks and workflow documentation
+├── keys/                         # Public SSH key(s) only
+└── soc-cms/                      # CMS content redirects
 ```
 
----
-
-
-## Workflow Documentation
-
-For a detailed explanation of the Git workflow in the current **MVP/dev-only** environment, see:
-
-➡️ [`docs/git-workflow-mvp.md`](docs/git-workflow-mvp.md)
+The Ghost host's Docker Compose stack, Caddy config, and boot scripts live under
+`opentofu/modules/vultr/instance/userdata/`.
 
 ---
 
-## Secrets Management
+## Getting started
 
-Secrets management is documented here: [`Secrets Management`](docs/secrets-management.md)
+### Prerequisites
+
+- A registered domain (this project uses `separationofconcerns.dev`)
+- A Cloudflare account (DNS + R2 enabled)
+- A Vultr account
+- A Bitwarden Secrets Manager account with a machine access token (`BWS_ACCESS_TOKEN`)
+- Docker (all tooling runs inside a container — nothing is installed on the host)
+
+### 1. Bootstrap the foundation (once per environment)
+
+Before the main stack can be deployed, a one-time bootstrap provisions the Cloudflare R2
+bucket that stores OpenTofu remote state and the Cloudflare DNS zone. Follow
+[`opentofu/bootstrap/README.md`](opentofu/bootstrap/README.md).
+
+### 2. Delegate the domain to Cloudflare
+
+The bootstrap apply outputs two Cloudflare nameservers. Set these as the custom nameservers
+at your registrar to delegate DNS control to Cloudflare.
+
+### 3. Work locally in the containerized shell
+
+All OpenTofu commands run inside the `ghost-stack-shell` container so the host stays clean
+and secrets are injected at runtime rather than written to disk.
+
+```bash
+# Full shell — builds the image and injects all secrets from Bitwarden
+./docker/scripts/infra-shell.sh
+
+# No-credentials shell — for fmt and tests only
+./docker/scripts/infra-shell.sh --no-secrets
+```
+
+Inside the container, use the wrapper script:
+
+```bash
+./opentofu/scripts/tofu.sh dev fmt      # Format check
+./opentofu/scripts/tofu.sh dev test     # Unit tests (mock providers, no credentials)
+./opentofu/scripts/tofu.sh dev plan     # Plan against dev
+./opentofu/scripts/tofu.sh dev apply    # Apply to dev
+```
+
+`fmt` and `test` require no credentials, so `--no-secrets` is enough for local validation.
 
 ---
 
-## Obtain A Domain For The Development Environment
+## Secrets
 
-1. Purchase a domain name (e.g., from Porkbun) for the dev environment. We picked **separationofconcerns.dev**
-2. Continue with the bootstrap process
+Two separate systems, by design (details in [`docs/secrets-management.md`](docs/secrets-management.md)):
 
-------
+- **Bitwarden Secrets Manager** holds infrastructure credentials (Cloudflare, Vultr,
+  Tailscale, Grafana, PagerDuty). They are fetched at runtime by `infra-shell.sh` and CI,
+  exported as `TF_VAR_*`, and never committed.
+- **Infisical** holds application secrets for Ghost. The instance fetches them at boot with
+  a single-use token and writes them to persistent block storage.
 
-## Bootstrap Infrastructure
-
-Before delegating the domain and running the main infrastructure, you must do a one time provisioning of R2 and DNS which is documented here: [`Bootstrap README`](opentofu/bootstrap/README.md)
-
-------
-
-## Delegating a Domain to Cloudflare
-
-1. After having run the bootstrap apply step above, OpenTofu will output two Cloudflare **nameservers**.
-2. In your domain registrar’s control panel:
-   - Find the section for setting custom nameservers.
-   - Replace the registrar’s default nameservers with the two from Cloudflare.
-
-This step delegates control of DNS to Cloudflare.
+No secret values live in git, cloud-init, or Butane. The reference IDs in the secrets docs
+are pointers into Bitwarden, not the secrets themselves.
 
 ---
 
-## Next Steps
+## CI/CD
 
-Part 2 will introduce:
+Three GitHub Actions workflows drive infrastructure changes (plus `claude-review.yml` for
+automated PR review and `sync-tryghost-compose.yml` for tracking upstream Ghost images):
 
-- Ghost instance provisioning on Vultr
-- DNS and TLS configuration
-- Cloudflare R2-backed OpenTofu state
-- Deeper network and access planning
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `pr-tofu-fmt-check.yml` | PR push (infra paths) | Enforce `tofu fmt` |
+| `pr-tofu-plan-develop.yml` | PR to `develop` (infra paths) | Run `tofu plan`, upload plan artifact |
+| `deploy-dev.yml` | Push to `develop` | Gated deploy: replays the PR plan, drift-checks, health-checks |
+
+Deploys require manual approval via GitHub environment protection and skip automatically
+when a PR contains no infrastructure changes. See
+[`docs/automated-deployment-workflow.md`](docs/automated-deployment-workflow.md) for the
+full pipeline and [`docs/git-workflow-mvp.md`](docs/git-workflow-mvp.md) for the branching
+model.
+
+---
+
+## Documentation
+
+- [`CLAUDE.md`](CLAUDE.md) — the complete engineering and operations reference for this repo
+- [`docs/automated-deployment-workflow.md`](docs/automated-deployment-workflow.md) — the CI/CD pipeline in detail
+- [`docs/secrets-management.md`](docs/secrets-management.md) — the two-tier secrets model
+- [`docs/branch-protection-rules.md`](docs/branch-protection-rules.md) — branch protection setup
+- [`docs/runbooks/`](docs/runbooks/) — backup/restore, secrets migration, Renovate, Tailscale cleanup, Tinybird analytics, and more
+
+---
+
+## License
+
+See [`LICENSE`](LICENSE).

--- a/docs/git-workflow-mvp.md
+++ b/docs/git-workflow-mvp.md
@@ -1,25 +1,28 @@
-# Git Workflow: MVP / Dev-Only Stage
+# Git Workflow
 
-This project currently operates in a single-environment setup: **`dev` only**. As the infrastructure evolves, we'll adopt additional environments (staging, production), but this document describes the initial development workflow for the MVP phase.
+This project runs a single environment (`dev`) with a pull-request-based workflow and an
+automated GitHub Actions deployment pipeline. This document describes the branching model;
+for the deployment pipeline itself, see [`automated-deployment-workflow.md`](automated-deployment-workflow.md).
 
-## Goals of the MVP Git Workflow
+## Goals
 
-- Support **solo or small-team iteration**
+- Support solo or small-team iteration with GitHub as the source of truth
 - Ensure reproducibility of infrastructure using OpenTofu
-- Leverage a clean branch model with GitHub as the source of truth
-- Provide a foundation for future CI/CD and environment promotion
-- Secrets stored in **1Password GUI** (or your tool of choice), injected at runtime
+- Keep `develop` deployable at all times behind a gated pipeline
+- Manage secrets outside of git via Bitwarden Secrets Manager, injected at runtime
 
 ---
 
 ## Branch Structure
 
-| Branch    | Purpose                                       |
-|-----------|-----------------------------------------------|
-| `develop` | Primary working branch for infrastructure code |
-| `feature/*` | Optional short-lived branches for new resources or blog content |
+| Branch      | Purpose                                                          |
+|-------------|-----------------------------------------------------------------|
+| `main`      | Protected base branch; long-lived                               |
+| `develop`   | Integration branch — merges here trigger the gated dev deploy   |
+| `feature/*` | Short-lived branches (`feature/GHO-XX-short-description`)        |
 
-> There is **no `main` branch used yet** in this phase. All deployments come from `develop`.
+Both `main` and `develop` are protected: changes land via pull request, and commits must be
+verified (signed). See [`branch-protection-rules.md`](branch-protection-rules.md).
 
 ---
 
@@ -28,75 +31,84 @@ This project currently operates in a single-environment setup: **`dev` only**. A
 1. **Clone the repo**:
 
    ```bash
-   git clone https://github.com/noahwhite/ghost-stack-part1.git
-   cd ghost-stack-part1
+   git clone https://github.com/noahwhite/ghost-stack.git
+   cd ghost-stack
    ```
 
-2. **Create a feature branch** (optional):
+2. **Create a feature branch**:
 
    ```bash
-   git checkout -b feature/setup-vultr-vm
+   git checkout -b feature/GHO-XX-short-description
    ```
 
-3. **Make changes** to OpenTofu/Terraform modules or blog content.
+3. **Make changes** to OpenTofu modules or documentation.
 
-4. **Commit and push** to `develop`:
+4. **Commit and push** the feature branch, then open a PR against `develop`:
 
    ```bash
    git add .
    git commit -m "Add Vultr VM for Ghost app server"
-   git push origin develop
+   git push origin feature/GHO-XX-short-description
    ```
+
+   Do not push directly to `develop` or `main` — both are protected and require a PR with a
+   verified (signed) commit.
 
 ---
 
 ## Deployment
 
-Infrastructure is managed manually using the Docker-based development shell.
+Infrastructure changes are validated and deployed automatically:
+
+- Opening a PR against `develop` runs `tofu fmt` and `tofu plan`, uploading the plan as an
+  artifact (infrastructure paths only).
+- Merging to `develop` triggers `deploy-dev.yml`, which replays the PR plan, checks for
+  drift, applies behind a manual approval gate, and runs post-deploy health checks.
+
+See [`automated-deployment-workflow.md`](automated-deployment-workflow.md) for the full
+pipeline.
+
+---
+
+## Running OpenTofu Locally
+
+Infrastructure tooling runs inside the `ghost-stack-shell` container so the host stays clean
+and secrets are injected at runtime.
 
 ### Run the Dev Shell
 
 ```bash
+# Full shell — secrets injected from Bitwarden Secrets Manager
 ./docker/scripts/infra-shell.sh
+
+# No-credentials shell — for fmt and tests only
+./docker/scripts/infra-shell.sh --no-secrets
 ```
 
-This shell provides:
+The container provides OpenTofu 1.11.1 plus standard CLI tooling.
 
-- OpenTofu (1.10.5)
-- Ubuntu base image
-- Standard CLI tools (`curl`, `git`, etc.)
+### Plan and Apply
 
----
-
-## Secrets Management
-
-Before applying the infrastructure read [`Secrets Management`](secrets-management.md) for setting up and managing the required secrets.
-
----
-
-## Apply Infrastructure
-
-Once secrets are loaded in the current shell session:
+Use the wrapper script, which selects the environment and auto-loads `dev.auto.tfvars`
+(there is no `-var-file` to pass):
 
 ```bash
-cd opentofu/envs/dev
-tofu init
-tofu plan -var-file=dev.tfvars
-tofu apply -var-file=dev.tfvars
+./opentofu/scripts/tofu.sh dev fmt      # Format check (no credentials)
+./opentofu/scripts/tofu.sh dev test     # Unit tests with mock providers (no credentials)
+./opentofu/scripts/tofu.sh dev plan     # Plan against dev
+./opentofu/scripts/tofu.sh dev apply    # Apply to dev
 ```
+
+Before planning or applying against real infrastructure, read
+[`secrets-management.md`](secrets-management.md) to set up the required secrets.
 
 ---
 
 ## Future Evolution
 
-Once staging and production environments are introduced, this workflow will evolve to include:
-
-- Additional branches (`staging`, `main`)
-- CI/CD pipelines with GitHub Actions
-- Promotion logic via pull requests
-- Secrets managed via automation or external vaulting tools
-
-Stay tuned in future parts of the series.
+Additional environments (staging, production) and promotion logic would introduce further
+branches and workflows. The multi-environment, multi-tenant evolution of this platform is
+tracked in a separate project.
 
 ---
 

--- a/opentofu/bootstrap/README.md
+++ b/opentofu/bootstrap/README.md
@@ -19,30 +19,29 @@ These are required to enable remote state locking and DNS delegation in the MVP 
 ```
 bootstrap/
 ├── README.md
-├── main.tf
-├── outputs.tf
-├── variables.tf
+├── main.tofu
+├── outputs.tofu
+├── variables.tofu
 ├── envs/
 │   └── dev/
 │       └── dev.tfvars
 ├── modules/
 │   ├── cloudflare_zone/
-│   │   ├── main.tf
-|		|		├── outputs.tf
-│   │   └── variables.tf
+│   │   ├── main.tofu
+│   │   ├── outputs.tofu
+│   │   └── variables.tofu
 │   ├── email_routing/
-│   │   ├── main.tf
-|		|		├── outputs.tf
-│   │   └── variables.tf
+│   │   ├── main.tofu
+│   │   ├── outputs.tofu
+│   │   └── variables.tofu
 │   └── r2/
 │       ├── README.md
-│       ├── main.tf
-│       └── variables.tf
-├── scripts/
-│   ├── bootstrap-dev.sh
-│   ├── generate-bootstrap-token.sh
-│   ├── list-permission-groups.sh
-│   └── set-cloudflare-env.sh
+│       ├── main.tofu
+│       └── variables.tofu
+└── scripts/
+    ├── bootstrap-env.sh
+    ├── generate-bootstrap-token.sh
+    └── list-permission-groups.sh
 ```
 
 ---
@@ -53,17 +52,18 @@ bootstrap/
 
 Before starting, you must create a Cloudflare API token with permission to generate other tokens. This is referred to as the **dev-token-creator**.
 
-Follow the instructions in [`docs/secrets-management.md`](../../docs/secrets-management.md#manual-creation-instructions) to:
+See [`docs/secrets-management.md`](../../docs/secrets-management.md) for how this repo manages
+secrets. Create this token as follows:
 
-- Create this token with the `User: API Tokens - Edit` permission
-- Store it securely (e.g., in 1Password)
+- Create the token with the `User: API Tokens - Edit` permission
+- Store it securely in your secrets manager
 - Paste it into the prompt when running the bootstrap token generator script in Step 1
 
 You will also need your Cloudflare Account ID. The easiest way to obtain it is to simply copy it from the Cloudflare dashboard URL after you have created the bootstrap API token. The account ID is the long string of characters in the URL directly between dash.cloudflare.com/ and /api-tokens. For example:
 
 https://dash.cloudflare.com/<CLOUDFLARE ACCOUNT ID>/api-tokens
 
-- Store it securely (e.g., in 1Password)
+- Store it securely in your secrets manager
 - Paste it into the prompt when running the bootstrap token generator script in Step 1
 
 ### Step 1: Enable R2 In Your Cloudflare Account
@@ -78,10 +78,10 @@ Before you are able to use R2 you must first enable billing on it.
 Once you have your bootstrap token, you can use it to generate a Cloudflare API token with the correct scopes:
 
 ```bash
-./opentofu/bootstrap/scripts/generate-cloudflare-token.sh
+./opentofu/bootstrap/scripts/generate-bootstrap-token.sh
 ```
 
-This will securely prompt you for your Cloudflare Account ID and Bootstrap Token, generate a signed JWT with R2 + DNS scopes, and copy it to your clipboard. Paste it into your secrets manager (e.g., 1Password).
+This will securely prompt you for your Cloudflare Account ID and Bootstrap Token, generate a signed JWT with R2 + DNS scopes, and copy it to your clipboard. Paste it into your secrets manager.
 
 ### Step 3: Export Secrets in Your Host Shell & Launch Docker Shell with Secrets Injected
 
@@ -161,4 +161,4 @@ This would render your infrastructure **unusable**.
 
 ---
 
-Ready to deploy the main infrastructure stack? Head over to `opentofu/main/` once bootstrap is complete.
+Ready to deploy the main infrastructure stack? Head over to `opentofu/envs/dev/` once bootstrap is complete.


### PR DESCRIPTION
## Summary

A documentation-accuracy audit found the top-level `README.md` and its two linked docs frozen at an early "MVP / Part 1" snapshot that no longer matches the codebase — with commands, paths, and cross-references that fail as written. Security was clean (no secrets in tree or history; the UUIDs in `docs/secrets-management.md` are Bitwarden reference IDs, not values), so this PR is purely a presentation/accuracy fix.

**Docs-only — no infrastructure files touched, so no plan/deploy workflow is triggered.**

## Changes

### `README.md` (rewrite)
- Reflects the actual current stack: Flatcar/Butane/Ignition, Docker Compose (Ghost, MySQL, Caddy, ActivityPub, Traffic Analytics), Bitwarden + Infisical two-tier secrets, Tailscale-only SSH, Grafana Cloud, PagerDuty, tiered R2 backups.
- Accurate directory tree (real `.tofu` layout and module names) and working commands (`infra-shell.sh`, `./opentofu/scripts/tofu.sh dev <cmd>`).
- Removes stale content: `.tf` extensions, "1Password", phantom scripts, and the "Part 2 will introduce…" list for features that already exist (Ghost provisioning, TLS, R2-backed state).

### `docs/git-workflow-mvp.md`
- Clone URL `ghost-stack-part1` → `ghost-stack`.
- 1Password → Bitwarden Secrets Manager.
- Corrects that `main` exists and both `main`/`develop` are protected + PR-gated (was "no `main` branch yet" / push-directly-to-develop).
- OpenTofu `1.10.5` → `1.11.1` (matches the Dockerfile).
- `tofu plan -var-file=dev.tfvars` → the `./opentofu/scripts/tofu.sh` wrapper (auto-loads `dev.auto.tfvars`; no such `dev.tfvars`).
- Points to `automated-deployment-workflow.md` for the real CI/CD pipeline instead of describing it as "future."

### `opentofu/bootstrap/README.md`
- Directory tree `.tf` → `.tofu`.
- Fixes phantom script names: `generate-cloudflare-token.sh` → `generate-bootstrap-token.sh`; drops nonexistent `bootstrap-dev.sh` / `set-cloudflare-env.sh` (real: `bootstrap-env.sh`).
- Removes dead `secrets-management.md#manual-creation-instructions` anchor.
- Final pointer `opentofu/main/` → `opentofu/envs/dev/`.

## Verification
- Every relative link in the changed docs resolves to a file that exists (checked programmatically).
- No residual `1Password`, `ghost-stack-part1`, phantom script names, `.tf`-in-tree, `1.10.5`, or `-var-file=dev.tfvars` references remain.

## Follow-ups (not in this PR)
- **`opentofu/envs/dev/dev.auto.tfvars`**: `ghost_url = "http://separationofconverns.dev"` — domain typo (`converns` → `concerns`) and `http` → `https`. Left out here because editing a `*.tfvars` file trips the infra path-filter and would trigger the gated deploy; worth a separate infra PR.
- Consider flipping the repo's **default branch** `main` → `develop` so visitors land on the real work.
