### PR TITLE
fix(dev): correct ghost_url domain typo and use https

### DIFF
--- a/opentofu/envs/dev/dev.auto.tfvars
+++ b/opentofu/envs/dev/dev.auto.tfvars
@@ -6,7 +6,7 @@ instance_plan   = "vhf-2c-4gb" # pick a plan slug
 
 ssh_key_name = "ghost-dev-admin"
 
-ghost_url = "http://separationofconverns.dev"
+ghost_url = "https://separationofconcerns.dev"
 
 block_storage_size_gb = 25
 block_storage_label   = "ghost-block"


### PR DESCRIPTION
## Summary

`opentofu/envs/dev/dev.auto.tfvars` set:

```hcl
ghost_url = "http://separationofconverns.dev"
```

Two bugs in one value:
- **Domain typo** — `separationofconverns.dev` is a misspelling of the project domain `separationofconcerns.dev`.
- **Scheme** — `http` instead of `https`. Caddy terminates TLS and serves the site over HTTPS, so Ghost should be configured with the `https` URL to generate canonical links, correct redirects, and secure cookies.

Fixed to:

```hcl
ghost_url = "https://separationofconcerns.dev"
```

## Impact

This is an input variable consumed by the Ghost instance module. Applying it updates Ghost's configured site URL. This is a `*.tfvars` change, so it is picked up by the infra path filter — the PR runs `tofu plan`, and merging to `develop` triggers the **gated** `deploy-dev.yml` (manual approval required before apply). Review the plan artifact before approving.

Split out from the README/docs-accuracy PR (#388) precisely because it touches infrastructure config rather than docs.
